### PR TITLE
Fix top nav visibility

### DIFF
--- a/css/modules/navigation.css
+++ b/css/modules/navigation.css
@@ -9,7 +9,7 @@
     right: 0;
     height: 70px;
     z-index: 1000;
-    display: none; /* Initially hidden */
+    /* display is controlled with the .hidden class */
     box-shadow: 0 2px 10px rgba(0,0,0,0.1);
     border-bottom: 1px solid rgba(244, 208, 54, 0.2);
 }


### PR DESCRIPTION
## Summary
- ensure the navigation bar can become visible by removing the default `display:none`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68806bbcb5208327ac3e9765d1e6e2ff