### PR TITLE
Improve nav bar styling

### DIFF
--- a/css/modules/navigation.css
+++ b/css/modules/navigation.css
@@ -36,22 +36,42 @@
     transform: translateY(-50%);
     display: flex;
     align-items: center;
-    gap: 20px;
+    gap: 12px;
     font-size: 14px;
+    line-height: 1.4;
     color: #333;
 }
 
+.nav-info .info-item {
+    position: relative;
+    padding: 0 4px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.nav-info .info-item + .info-item::before {
+    content: '|';
+    position: absolute;
+    left: -8px;
+    color: #999;
+}
+
 .export-btn {
-    padding: 4px 8px;
+    padding: 6px 12px;
     font-size: 14px;
-    border: 1px solid #ccc;
-    background-color: #fff;
+    border: none;
+    background-color: #2b3990;
+    color: #fff;
     border-radius: 4px;
     cursor: pointer;
+    display: flex;
+    align-items: center;
+    gap: 4px;
 }
 
 .export-btn:hover {
-    background-color: #f3f4f6;
+    background-color: #1e2a70;
 }
 
 
@@ -65,11 +85,21 @@
     padding: 8px 12px;
     border-radius: 4px;
     background-color: rgba(244, 208, 54, 0.08); /* Same as nav bar background */
+    gap: 8px;
+    transition: opacity 0.3s ease;
+    cursor: pointer;
 }
 
 .nav-brand img {
     height: 32px;
-    margin-right: 12px;
+}
+
+.nav-brand:hover span {
+    opacity: 0.8;
+}
+
+#nav-datetime {
+    font-family: "Courier New", monospace;
 }
 
 .nav-brand:hover {

--- a/index.html
+++ b/index.html
@@ -28,9 +28,9 @@
                         </ul>
                     </div>
                     <div id="nav-info-display" class="nav-info">
-                        <span id="nav-student-info"></span>
-                        <span id="nav-datetime"></span>
-                        <button id="export-btn" class="export-btn">Export CSV</button>
+                        <span id="nav-student-info" class="info-item"></span>
+                        <span id="nav-datetime" class="info-item"></span>
+                        <button id="export-btn" class="export-btn">📤 Export CSV</button>
                     </div>
                 </div>
             </nav>

--- a/js/modules/ui.js
+++ b/js/modules/ui.js
@@ -232,11 +232,15 @@ export function updateInfoDisplay() {
     
     const studentName = state.userResponses['q1_child_name'] || 'N/A';
     const studentAge = state.userResponses['q2_child_age'] || 'N/A';
-    
-    studentInfoEl.textContent = `Name: ${studentName}, Age: ${studentAge}`;
+
+    const studentInfo = `Name: ${studentName} | Age: ${studentAge}`;
+    studentInfoEl.textContent = studentInfo;
+    studentInfoEl.title = studentInfo;
     
     const now = new Date();
     const dateString = now.toLocaleDateString();
     const timeString = now.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', hour12: false });
-    datetimeEl.textContent = `${dateString} ${timeString}`;
+    const datetimeString = `${dateString} ${timeString}`;
+    datetimeEl.textContent = datetimeString;
+    datetimeEl.title = datetimeString;
 }


### PR DESCRIPTION
## Summary
- style nav info items for clearer alignment
- enhance export button appearance
- refine nav-brand spacing and add hover fade
- show date/time in monospace font
- render name and age with `|` separators and tooltips

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68806d425b748327addda048b68c6ad4