### PR TITLE
UI improvements and id mapping integration

### DIFF
--- a/assets/tasks/background.json
+++ b/assets/tasks/background.json
@@ -45,6 +45,19 @@
       }
     },
     {
+      "id": "child-name",
+      "type": "text",
+      "label": {
+        "en": "Child's Name",
+        "zh": "小朋友姓名"
+      },
+      "placeholder": {
+        "en": "Auto-filled",
+        "zh": "自動填寫"
+      },
+      "required": true
+    },
+    {
       "id": "gender",
       "type": "select",
       "label": {
@@ -63,29 +76,5 @@
       ]
     }
   ],
-  "questions": [
-    {
-      "id": "q1_child_name",
-      "type": "text",
-      "label": {
-        "en": "Child's Name",
-        "zh": "小朋友姓名"
-      },
-      "required": true
-    },
-    {
-      "id": "q2_child_age",
-      "type": "text",
-      "inputType": "number",
-      "label": {
-        "en": "Child's Age",
-        "zh": "小朋友年齡"
-      },
-      "required": true,
-      "validation": {
-        "min": 3,
-        "max": 6
-      }
-    }
-  ]
+  "questions": []
 }

--- a/css/modules/navigation.css
+++ b/css/modules/navigation.css
@@ -91,7 +91,7 @@
 }
 
 .nav-brand img {
-    height: 32px;
+    height: 50px;
 }
 
 .nav-brand:hover span {

--- a/index.html
+++ b/index.html
@@ -15,7 +15,6 @@
                 <div class="nav-container">
                     <a href="#" id="home-btn" class="nav-brand">
                         <img src="assets/logos/KS.png" alt="KeySteps Logo">
-                        <span>KeySteps@JC</span>
                     </a>
                     <div id="nav-info-display" class="nav-info">
                         <span id="nav-student-info" class="info-item"></span>

--- a/js/modules/events.js
+++ b/js/modules/events.js
@@ -1,6 +1,8 @@
 import { startSurvey, showToc, toggleLanguage, navigatePage } from './navigation.js';
 import { hideRequiredModal } from './ui.js';
 import { exportResponsesToCsv } from './export.js';
+import { findStudent } from './id-mapping.js';
+import { state } from './state.js';
 
 export function initializeEventListeners() {
     document.getElementById('start-survey-btn').addEventListener('click', startSurvey);
@@ -13,4 +15,30 @@ export function initializeEventListeners() {
     if (exportBtn) {
         exportBtn.addEventListener('click', exportResponsesToCsv);
     }
+    attachEntryFormListeners();
+}
+
+export function attachEntryFormListeners() {
+    const sid = document.getElementById('student-id');
+    const sch = document.getElementById('school-id');
+    if (!sid || !sch) return;
+
+    const handle = () => {
+        const student = findStudent(sid.value.trim(), sch.value.trim());
+        if (student) {
+            const genderEl = document.getElementById('gender');
+            if (genderEl) {
+                genderEl.value = student.gender.toLowerCase() === 'm' ? 'male' : 'female';
+                state.userResponses['gender'] = genderEl.value;
+            }
+            const nameEl = document.getElementById('child-name');
+            if (nameEl) {
+                nameEl.value = student.name;
+                state.userResponses['child-name'] = student.name;
+            }
+        }
+    };
+
+    sid.addEventListener('blur', handle);
+    sch.addEventListener('blur', handle);
 }

--- a/js/modules/id-mapping.js
+++ b/js/modules/id-mapping.js
@@ -1,0 +1,78 @@
+export const idMapping = {
+    students: {},
+    schools: {}
+};
+
+function parseCSV(text) {
+    const lines = text.trim().split(/\r?\n/);
+    const headers = lines.shift().split(',');
+    return lines.map(line => {
+        const values = [];
+        let current = '';
+        let inQuotes = false;
+        for (let i = 0; i < line.length; i++) {
+            const char = line[i];
+            if (char === '"') {
+                if (inQuotes && line[i + 1] === '"') {
+                    current += '"';
+                    i++;
+                } else {
+                    inQuotes = !inQuotes;
+                }
+            } else if (char === ',' && !inQuotes) {
+                values.push(current);
+                current = '';
+            } else {
+                current += char;
+            }
+        }
+        values.push(current);
+        const obj = {};
+        headers.forEach((h, idx) => {
+            obj[h.trim()] = (values[idx] || '').trim();
+        });
+        return obj;
+    });
+}
+
+export function loadIdMappings() {
+    const studentPromise = fetch('assets/id_mapping/coreid.csv')
+        .then(res => res.text())
+        .then(txt => {
+            const rows = parseCSV(txt);
+            rows.forEach(r => {
+                const sid = (r['Student ID Copy'] || '').replace(/^[^0-9]*/, '');
+                idMapping.students[sid] = {
+                    name: r['Student Name'] || '',
+                    schoolId: r['School ID'] || '',
+                    gender: r['Gender'] || ''
+                };
+            });
+        });
+
+    const schoolPromise = fetch('assets/id_mapping/schoolid.csv')
+        .then(res => res.text())
+        .then(txt => {
+            const rows = parseCSV(txt);
+            rows.forEach(r => {
+                idMapping.schools[r['School ID']] = {
+                    name: r['School Name (Chinese)'] || ''
+                };
+            });
+        });
+
+    return Promise.all([studentPromise, schoolPromise]);
+}
+
+export function findStudent(studentId, schoolId) {
+    const sid = String(studentId).replace(/^[^0-9]*/, '');
+    const student = idMapping.students[sid];
+    if (student && (!schoolId || student.schoolId === schoolId)) {
+        return student;
+    }
+    return null;
+}
+
+export function findSchool(schoolId) {
+    return idMapping.schools[schoolId] || null;
+}

--- a/js/modules/navigation.js
+++ b/js/modules/navigation.js
@@ -46,12 +46,14 @@ export function navigatePage(direction) {
         state.userResponses[question.id] = value;
         logDebug('Saved response:', question.id, '=', value);
         saveToLocal();
-        if (question.id === 'q1_child_name' || question.id === 'q2_child_age') {
+        if (question.id === 'child-name') {
             updateInfoDisplay();
         }
     }
 
-    if (newPage >= 0 && newPage < section.questions.length) {
+    if (newPage < 0) {
+        showToc();
+    } else if (newPage >= 0 && newPage < section.questions.length) {
         state.currentPage = newPage;
         renderCurrentQuestion();
     } else if (newPage >= section.questions.length) {
@@ -113,12 +115,19 @@ export function startSurvey() {
     });
 
     if (isValid) {
+        const summary = `Student ID: ${state.userResponses['student-id']}\n` +
+                        `School ID: ${state.userResponses['school-id']}\n` +
+                        `Name: ${state.userResponses['child-name']}\n` +
+                        `Gender: ${state.userResponses['gender']}`;
+        if (!confirm(summary)) return;
+
         loadAutosave(state.userResponses['student-id']).then(saved => {
             if (saved) {
                 Object.assign(state.userResponses, saved.responses || {});
                 Object.assign(state.completionTimes, saved.completionTimes || {});
             }
             startAutosave();
+            state.backgroundCompleted = true;
             showToc();
         });
     }

--- a/js/modules/state.js
+++ b/js/modules/state.js
@@ -6,8 +6,10 @@ export const state = {
     currentSectionId: null,
     backgroundCompleted: false,
     userResponses: {
-        'q1_child_name': '',
-        'q2_child_age': ''
+        'child-name': '',
+        'gender': '',
+        'student-id': '',
+        'school-id': ''
     },
     completionTimes: {},
     infoDisplayInterval: null,

--- a/js/modules/ui.js
+++ b/js/modules/ui.js
@@ -57,6 +57,7 @@ export function renderEntryForm() {
         formGroup.appendChild(errorDiv);
         entryFormContainer.appendChild(formGroup);
     });
+    import('./events.js').then(m => m.attachEntryFormListeners());
 }
 
 export function renderToc() {
@@ -120,14 +121,12 @@ export function renderToc() {
 
         set.sections.forEach(sectionInfo => {
             const sectionId = sectionInfo.file.replace('.json', '');
+            if (sectionId === 'background') return; // skip background section in TOC
             const section = state.surveySections[sectionId];
             if (section) {
                 const isEnabled = set.order === 1 || state.backgroundCompleted;
                 logDebug(`renderToc:   - Section: ${sectionId}, Enabled: ${isEnabled}`);
                 const tocItem = createTocItem(section, isEnabled);
-                if (sectionId === 'background' && !state.backgroundCompleted) {
-                    tocItem.classList.add('highlight');
-                }
                 setContainer.appendChild(tocItem);
             } else {
                 logDebug(`renderToc:   - Section data for ${sectionId} not found in state.surveySections.`);
@@ -230,10 +229,8 @@ export function updateInfoDisplay() {
     const studentInfoEl = document.getElementById('nav-student-info');
     const datetimeEl = document.getElementById('nav-datetime');
     
-    const studentName = state.userResponses['q1_child_name'] || 'N/A';
-    const studentAge = state.userResponses['q2_child_age'] || 'N/A';
-
-    const studentInfo = `Name: ${studentName} | Age: ${studentAge}`;
+    const studentName = state.userResponses['child-name'] || 'N/A';
+    const studentInfo = `Name: ${studentName}`;
     studentInfoEl.textContent = studentInfo;
     studentInfoEl.title = studentInfo;
     

--- a/js/script.js
+++ b/js/script.js
@@ -4,11 +4,13 @@ import { renderEntryForm, renderToc } from './modules/ui.js';
 import { initializeEventListeners } from './modules/events.js';
 import { startSurvey, toggleLanguage, navigateToSection, navigatePage } from './modules/navigation.js';
 import { initializeDebug } from './modules/debug.js';
+import { loadIdMappings } from './modules/id-mapping.js';
 
 document.addEventListener('DOMContentLoaded', () => {
     document.getElementById('top-nav').classList.add('hidden');
 
-    fetchSurveyData()
+    loadIdMappings()
+        .then(fetchSurveyData)
         .then(() => {
             renderEntryForm();
             renderToc();


### PR DESCRIPTION
## Summary
- add id mapping module to parse `coreid.csv` and `schoolid.csv`
- auto-populate entry form fields via new listeners
- confirm child info before starting survey
- hide background section and remove age question
- enlarge navbar logo and remove brand text
- allow Back button to return home from first survey page

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_68807e297a1c83279fe779f63c960577