### PR TITLE
Add school name lookup and update student mapping

### DIFF
--- a/assets/tasks/background.json
+++ b/assets/tasks/background.json
@@ -45,6 +45,18 @@
       }
     },
     {
+      "id": "school-name",
+      "type": "text",
+      "label": {
+        "en": "School Name",
+        "zh": "學校名稱"
+      },
+      "placeholder": {
+        "en": "Auto-filled",
+        "zh": "自動填寫"
+      }
+    },
+    {
       "id": "child-name",
       "type": "text",
       "label": {

--- a/js/modules/events.js
+++ b/js/modules/events.js
@@ -1,7 +1,7 @@
 import { startSurvey, showToc, toggleLanguage, navigatePage } from './navigation.js';
 import { hideRequiredModal } from './ui.js';
 import { exportResponsesToCsv } from './export.js';
-import { findStudent } from './id-mapping.js';
+import { findStudent, findSchool } from './id-mapping.js';
 import { state } from './state.js';
 
 export function initializeEventListeners() {
@@ -35,6 +35,14 @@ export function attachEntryFormListeners() {
             if (nameEl) {
                 nameEl.value = student.name;
                 state.userResponses['child-name'] = student.name;
+            }
+        }
+        const school = findSchool(sch.value.trim());
+        if (school) {
+            const schoolNameEl = document.getElementById('school-name');
+            if (schoolNameEl) {
+                schoolNameEl.value = school.name;
+                state.userResponses['school-name'] = school.name;
             }
         }
     };

--- a/js/modules/id-mapping.js
+++ b/js/modules/id-mapping.js
@@ -46,8 +46,8 @@ export function loadIdMappings() {
         .then(txt => {
             const rows = parseCSV(txt);
             rows.forEach(r => {
-                const sid = (r['Student ID Copy'] || '').replace(/^[^0-9]*/, '');
-                idMapping.students[sid] = {
+                const cid = (r['Core ID'] || '').replace(/^[^0-9]*/, '');
+                idMapping.students[cid] = {
                     name: r['Student Name'] || '',
                     schoolId: r['School ID'] || '',
                     gender: r['Gender'] || ''
@@ -85,12 +85,19 @@ export function loadIdMappings() {
 export function findStudent(studentId, schoolId) {
     const sid = String(studentId).replace(/^[^0-9]*/, '');
     const student = idMapping.students[sid];
-    if (student && (!schoolId || student.schoolId === schoolId)) {
+    if (student && (!schoolId || student.schoolId === formatSchoolId(schoolId))) {
         return student;
     }
     return null;
 }
 
+function formatSchoolId(id) {
+    if (!id) return id;
+    const num = String(id).replace(/^[^0-9]*/, '');
+    return `S${num.padStart(3, '0')}`;
+}
+
 export function findSchool(schoolId) {
-    return idMapping.schools[schoolId] || null;
+    const formatted = formatSchoolId(schoolId);
+    return idMapping.schools[formatted] || null;
 }

--- a/js/modules/navigation.js
+++ b/js/modules/navigation.js
@@ -118,6 +118,7 @@ export function startSurvey() {
     if (isValid) {
         const summary = `Student ID: ${state.userResponses['student-id']}\n` +
                         `School ID: ${state.userResponses['school-id']}\n` +
+                        `School Name: ${state.userResponses['school-name']}\n` +
                         `Name: ${state.userResponses['child-name']}\n` +
                         `Gender: ${state.userResponses['gender']}`;
         if (!confirm(summary)) return;

--- a/js/modules/state.js
+++ b/js/modules/state.js
@@ -9,7 +9,8 @@ export const state = {
         'child-name': '',
         'gender': '',
         'student-id': '',
-        'school-id': ''
+        'school-id': '',
+        'school-name': ''
     },
     completionTimes: {},
     infoDisplayInterval: null,


### PR DESCRIPTION
## Summary
- map student IDs using `Core ID`
- auto-fill school name from `schoolid.csv`
- add `school-name` form field and track it in state
- show the mapped school name in the start summary

## Testing
- `node -e "JSON.parse(require('fs').readFileSync('assets/tasks/background.json'));console.log('ok');"`
- `node -e "require('./js/modules/id-mapping.js'); console.log('id module loaded');"`

------
https://chatgpt.com/codex/tasks/task_e_6880846a9a548327b3f207eab42858a5