### PR TITLE
Add survey progress and timestamp tracking

### DIFF
--- a/css/modules/pages.css
+++ b/css/modules/pages.css
@@ -54,6 +54,14 @@
     margin-bottom: 30px;
 }
 
+#toc-start-date,
+#toc-end-date {
+    font-size: 14px;
+    color: #666;
+    margin: 5px 0;
+    text-align: left;
+}
+
 #toc-list {
     display: flex;
     flex-direction: column;
@@ -65,6 +73,9 @@
     border: 2px solid #e9ecef;
     border-radius: 8px;
     padding: 20px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
     cursor: pointer;
     transition: all 0.3s ease;
     text-align: left;
@@ -96,6 +107,12 @@
     font-size: 18px;
     font-weight: bold;
     color: #333;
+    margin-bottom: 5px;
+}
+
+.toc-item-progress {
+    font-size: 14px;
+    color: #666;
     margin-bottom: 5px;
 }
 

--- a/index.html
+++ b/index.html
@@ -50,6 +50,8 @@
                     <div class="toc-container">
                         <h2 id="toc-title" data-lang-zh="問卷部分" data-lang-en="Survey Sections">問卷部分</h2>
                         <p id="toc-instructions" data-lang-zh="請選擇一個部分開始問卷。" data-lang-en="Please select a section to begin the survey.">請選擇一個部分開始問卷。</p>
+                        <p id="toc-start-date"></p>
+                        <p id="toc-end-date"></p>
                         <div id="toc-list">
                             <!-- Table of Contents sections will be loaded here -->
                         </div>

--- a/js/modules/autosave.js
+++ b/js/modules/autosave.js
@@ -1,11 +1,31 @@
-import { state } from './state.js';
+import { state, formatTimestamp } from './state.js';
 
 const AUTOSAVE_INTERVAL = 30000; // 30 seconds
+const END_UPDATE_INTERVAL = 60000; // 60 seconds
 let autosaveTimer = null;
+let endDateTimer = null;
 
 export function startAutosave() {
     if (autosaveTimer) return;
     autosaveTimer = setInterval(saveToLocal, AUTOSAVE_INTERVAL);
+    endDateTimer = setInterval(updateEndDate, END_UPDATE_INTERVAL);
+}
+
+export function stopAutosave() {
+    if (autosaveTimer) {
+        clearInterval(autosaveTimer);
+        autosaveTimer = null;
+    }
+    if (endDateTimer) {
+        clearInterval(endDateTimer);
+        endDateTimer = null;
+    }
+}
+
+function updateEndDate() {
+    if (state.completed) return;
+    state.endDate = formatTimestamp(new Date());
+    saveToLocal();
 }
 
 export function saveToLocal() {
@@ -13,7 +33,11 @@ export function saveToLocal() {
     if (!studentId) return;
     const data = {
         responses: state.userResponses,
-        completionTimes: state.completionTimes
+        completionTimes: state.completionTimes,
+        startDate: state.startDate,
+        endDate: state.endDate,
+        viewedQuestions: state.viewedQuestions,
+        completed: state.completed
     };
     localforage.setItem(`autosave_${studentId}`, data).catch(console.error);
 }

--- a/js/modules/events.js
+++ b/js/modules/events.js
@@ -61,6 +61,10 @@ export function attachEntryFormListeners() {
                 if (saved) {
                     Object.assign(state.userResponses, saved.responses || {});
                     Object.assign(state.completionTimes, saved.completionTimes || {});
+                    state.startDate = saved.startDate || state.startDate;
+                    state.endDate = saved.endDate || state.endDate;
+                    state.viewedQuestions = saved.viewedQuestions || {};
+                    state.completed = saved.completed || false;
                     const bg = state.surveySections['background'];
                     if (bg && bg.entryForm) {
                         bg.entryForm.forEach(field => {

--- a/js/modules/export.js
+++ b/js/modules/export.js
@@ -5,6 +5,8 @@ export function exportResponsesToCsv() {
     for (const section in state.completionTimes) {
         combined[`completed_${section}`] = state.completionTimes[section];
     }
+    combined.startDate = state.startDate;
+    combined.endDate = state.endDate;
     const headers = Object.keys(combined);
     const rows = [headers, headers.map(h => combined[h] ?? '')];
     const csvContent = rows

--- a/js/modules/question.js
+++ b/js/modules/question.js
@@ -17,6 +17,11 @@ export function renderCurrentQuestion() {
         return;
     }
 
+    if (!state.viewedQuestions) {
+        state.viewedQuestions = {};
+    }
+    state.viewedQuestions[question.id] = true;
+
     questionContainer.innerHTML = ''; // Clear previous question
 
     // Update header

--- a/js/modules/state.js
+++ b/js/modules/state.js
@@ -12,9 +12,19 @@ export const state = {
         'school-name': ''
     },
     completionTimes: {},
+    startDate: null,
+    endDate: null,
+    viewedQuestions: {},
+    completed: false,
     infoDisplayInterval: null,
     debugMode: false
 };
+
+export function formatTimestamp(date) {
+    const pad = n => String(n).padStart(2, '0');
+    return `${date.getFullYear()}${pad(date.getMonth() + 1)}${pad(date.getDate())} ` +
+           `${pad(date.getHours())}:${pad(date.getMinutes())}`;
+}
 
 export function logDebug(...args) {
     if (state.debugMode) {

--- a/js/modules/ui.js
+++ b/js/modules/ui.js
@@ -90,8 +90,11 @@ export function renderToc() {
         const tocItem = document.createElement('div');
         tocItem.className = 'toc-item';
         tocItem.dataset.section = section.id;
+        const answered = section.questions.filter(q => state.userResponses[q.id]).length;
+        const total = section.questions.length;
         tocItem.innerHTML = `
             <div class="toc-item-title">${section.title[state.currentLanguage] || section.title.en || section.id}</div>
+            <div class="toc-item-progress">${answered}/${total}</div>
             <div class="toc-item-arrow">→</div>
         `;
         tocItem.addEventListener('click', () => {
@@ -134,6 +137,7 @@ export function renderToc() {
         tocList.appendChild(setContainer);
     });
     logDebug('renderToc: Finished rendering TOC.');
+    updateSurveyTimestamps();
 }
 
 export function renderSectionJumper() {
@@ -214,4 +218,15 @@ export function updateInfoDisplay() {
     const datetimeString = `${dateString} ${timeString}`;
     datetimeEl.textContent = datetimeString;
     datetimeEl.title = datetimeString;
+}
+
+export function updateSurveyTimestamps() {
+    const startEl = document.getElementById('toc-start-date');
+    const endEl = document.getElementById('toc-end-date');
+    if (startEl) {
+        startEl.textContent = `Started: ${state.startDate || '-'}`;
+    }
+    if (endEl) {
+        endEl.textContent = `Last Used: ${state.endDate || '-'}`;
+    }
 }


### PR DESCRIPTION
## Summary
- show progress counts in TOC
- record survey start/end timestamps and viewed questions in autosave
- expose timestamps in TOC and autosave
- include timestamps when exporting responses

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68809f1155d483278c49113603f44a88