### PR TITLE
Show per-task timestamps in TOC

### DIFF
--- a/css/modules/pages.css
+++ b/css/modules/pages.css
@@ -75,7 +75,7 @@
     padding: 20px;
     display: flex;
     justify-content: space-between;
-    align-items: center;
+    align-items: flex-start;
     cursor: pointer;
     transition: all 0.3s ease;
     text-align: left;
@@ -94,9 +94,6 @@
     color: #6c757d;
 }
 
-.toc-item.disabled .toc-item-arrow {
-    display: none;
-}
 
 .toc-item.highlight {
     border-color: #f99d33; /* Orange from palette */
@@ -116,12 +113,19 @@
     margin-bottom: 5px;
 }
 
-.toc-item-arrow {
-    float: right;
-    color: #2b3990;
-    font-size: 20px;
-    font-weight: bold;
+.toc-item-info {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
 }
+
+.toc-item-times {
+    display: flex;
+    gap: 10px;
+    font-size: 12px;
+    color: #666;
+}
+
 
 .toc-set-header {
     margin: 20px 0 10px 0;

--- a/js/modules/autosave.js
+++ b/js/modules/autosave.js
@@ -34,6 +34,7 @@ export function saveToLocal() {
     const data = {
         responses: state.userResponses,
         completionTimes: state.completionTimes,
+        sectionTimestamps: state.sectionTimestamps,
         startDate: state.startDate,
         endDate: state.endDate,
         viewedQuestions: state.viewedQuestions,

--- a/js/modules/events.js
+++ b/js/modules/events.js
@@ -61,6 +61,7 @@ export function attachEntryFormListeners() {
                 if (saved) {
                     Object.assign(state.userResponses, saved.responses || {});
                     Object.assign(state.completionTimes, saved.completionTimes || {});
+                    state.sectionTimestamps = saved.sectionTimestamps || {};
                     state.startDate = saved.startDate || state.startDate;
                     state.endDate = saved.endDate || state.endDate;
                     state.viewedQuestions = saved.viewedQuestions || {};

--- a/js/modules/navigation.js
+++ b/js/modules/navigation.js
@@ -13,6 +13,13 @@ export function navigateToSection(sectionId) {
     logDebug('Navigating to section:', sectionId);
     state.currentSectionId = sectionId;
     state.currentPage = 0;
+    const now = formatTimestamp(new Date());
+    if (!state.sectionTimestamps[sectionId]) {
+        state.sectionTimestamps[sectionId] = { start: now, lastUsed: now };
+    } else {
+        state.sectionTimestamps[sectionId].lastUsed = now;
+    }
+    saveToLocal();
     loadSectionData(sectionId).then(() => {
         topNav.classList.remove('hidden');
         topNav.classList.add('visible');
@@ -71,6 +78,13 @@ export function navigatePage(direction) {
 }
 
 export function showToc() {
+    if (state.currentSectionId) {
+        const now = formatTimestamp(new Date());
+        const ts = state.sectionTimestamps[state.currentSectionId] || {};
+        ts.lastUsed = now;
+        state.sectionTimestamps[state.currentSectionId] = ts;
+        saveToLocal();
+    }
     renderToc();
     document.getElementById('top-nav').classList.add('hidden');
     document.body.classList.remove('nav-visible');
@@ -128,6 +142,7 @@ export function startSurvey() {
             if (saved) {
                 Object.assign(state.userResponses, saved.responses || {});
                 Object.assign(state.completionTimes, saved.completionTimes || {});
+                state.sectionTimestamps = saved.sectionTimestamps || {};
                 state.startDate = saved.startDate || formatTimestamp(new Date());
                 state.endDate = saved.endDate || state.startDate;
                 state.viewedQuestions = saved.viewedQuestions || {};

--- a/js/modules/state.js
+++ b/js/modules/state.js
@@ -12,6 +12,7 @@ export const state = {
         'school-name': ''
     },
     completionTimes: {},
+    sectionTimestamps: {},
     startDate: null,
     endDate: null,
     viewedQuestions: {},
@@ -31,3 +32,8 @@ export function logDebug(...args) {
         console.log('[DEBUG]', ...args);
     }
 }
+
+export const labelTranslations = {
+    started: { en: 'Started', zh: '開始' },
+    lastUsed: { en: 'Last Used', zh: '最後使用' }
+};

--- a/js/modules/ui.js
+++ b/js/modules/ui.js
@@ -1,4 +1,4 @@
-import { state, logDebug } from './state.js';
+import { state, logDebug, labelTranslations } from './state.js';
 import { navigateToSection } from './navigation.js';
 
 const entryPage = document.getElementById('entry-page');
@@ -90,13 +90,38 @@ export function renderToc() {
         const tocItem = document.createElement('div');
         tocItem.className = 'toc-item';
         tocItem.dataset.section = section.id;
+
         const answered = section.questions.filter(q => state.userResponses[q.id]).length;
         const total = section.questions.length;
-        tocItem.innerHTML = `
-            <div class="toc-item-title">${section.title[state.currentLanguage] || section.title.en || section.id}</div>
-            <div class="toc-item-progress">${answered}/${total}</div>
-            <div class="toc-item-arrow">→</div>
-        `;
+        const timestamps = state.sectionTimestamps[section.id] || {};
+
+        const info = document.createElement('div');
+        info.className = 'toc-item-info';
+
+        const title = document.createElement('div');
+        title.className = 'toc-item-title';
+        title.textContent = section.title[state.currentLanguage] || section.title.en || section.id;
+        info.appendChild(title);
+
+        const times = document.createElement('div');
+        times.className = 'toc-item-times';
+        const startedLabel = labelTranslations.started[state.currentLanguage];
+        const lastLabel = labelTranslations.lastUsed[state.currentLanguage];
+        const startSpan = document.createElement('span');
+        startSpan.textContent = `${startedLabel}: ${timestamps.start || '-'}`;
+        const lastSpan = document.createElement('span');
+        lastSpan.textContent = `${lastLabel}: ${timestamps.lastUsed || '-'}`;
+        times.appendChild(startSpan);
+        times.appendChild(lastSpan);
+        info.appendChild(times);
+
+        const progress = document.createElement('div');
+        progress.className = 'toc-item-progress';
+        progress.textContent = `${answered}/${total}`;
+
+        tocItem.appendChild(info);
+        tocItem.appendChild(progress);
+
         tocItem.addEventListener('click', () => {
             logDebug('TOC item clicked:', section.id);
             navigateToSection(section.id);
@@ -224,9 +249,11 @@ export function updateSurveyTimestamps() {
     const startEl = document.getElementById('toc-start-date');
     const endEl = document.getElementById('toc-end-date');
     if (startEl) {
-        startEl.textContent = `Started: ${state.startDate || '-'}`;
+        const startedLabel = labelTranslations.started[state.currentLanguage];
+        startEl.textContent = `${startedLabel}: ${state.startDate || '-'}`;
     }
     if (endEl) {
-        endEl.textContent = `Last Used: ${state.endDate || '-'}`;
+        const lastLabel = labelTranslations.lastUsed[state.currentLanguage];
+        endEl.textContent = `${lastLabel}: ${state.endDate || '-'}`;
     }
 }


### PR DESCRIPTION
## Summary
- track per-section timestamps in state
- save/load timestamps with autosave
- update navigation to record start/last-used times
- show start/last-used times for each survey item in the table of contents
- remove arrow indicator and tweak TOC styles
- localize start/last used labels

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6880a1c1c4488327b7f9d7cd0fc5c069