### PR TITLE
Enhance Chinese Word Reading styling

### DIFF
--- a/assets/tasks/ChineseWordReading.json
+++ b/assets/tasks/ChineseWordReading.json
@@ -15,7 +15,7 @@
     {
       "id": "CWR_1",
       "type": "radio",
-      "label": "「呢個係咩字？」\n山",
+      "label": "「呢個係咩字？」\n<span class="cwr-word">山</span>",
       "options": [
         {
           "value": "Y",
@@ -30,7 +30,7 @@
     {
       "id": "CWR_2",
       "type": "radio",
-      "label": "「呢個係咩字？」\n牛",
+      "label": "「呢個係咩字？」\n<span class="cwr-word">牛</span>",
       "options": [
         {
           "value": "Y",
@@ -45,7 +45,7 @@
     {
       "id": "CWR_3",
       "type": "radio",
-      "label": "「呢個係咩字？」\n花",
+      "label": "「呢個係咩字？」\n<span class="cwr-word">花</span>",
       "options": [
         {
           "value": "Y",
@@ -60,7 +60,7 @@
     {
       "id": "CWR_4",
       "type": "radio",
-      "label": "「呢個係咩字？」\n車",
+      "label": "「呢個係咩字？」\n<span class="cwr-word">車</span>",
       "options": [
         {
           "value": "Y",
@@ -75,7 +75,7 @@
     {
       "id": "CWR_5",
       "type": "radio",
-      "label": "「呢個係咩字？」\n水",
+      "label": "「呢個係咩字？」\n<span class="cwr-word">水</span>",
       "options": [
         {
           "value": "Y",
@@ -90,7 +90,7 @@
     {
       "id": "CWR_6",
       "type": "radio",
-      "label": "「呢個係咩字？」\n爸",
+      "label": "「呢個係咩字？」\n<span class="cwr-word">爸</span>",
       "options": [
         {
           "value": "Y",
@@ -105,7 +105,7 @@
     {
       "id": "CWR_7",
       "type": "radio",
-      "label": "「呢個係咩字？」\n哥",
+      "label": "「呢個係咩字？」\n<span class="cwr-word">哥</span>",
       "options": [
         {
           "value": "Y",
@@ -120,7 +120,7 @@
     {
       "id": "CWR_8",
       "type": "radio",
-      "label": "「呢個係咩字？」\n色",
+      "label": "「呢個係咩字？」\n<span class="cwr-word">色</span>",
       "options": [
         {
           "value": "Y",
@@ -135,7 +135,7 @@
     {
       "id": "CWR_9",
       "type": "radio",
-      "label": "「呢個係咩字？」\n風",
+      "label": "「呢個係咩字？」\n<span class="cwr-word">風</span>",
       "options": [
         {
           "value": "Y",
@@ -150,7 +150,7 @@
     {
       "id": "CWR_10",
       "type": "radio",
-      "label": "「呢個係咩字？」\n早",
+      "label": "「呢個係咩字？」\n<span class="cwr-word">早</span>",
       "options": [
         {
           "value": "Y",
@@ -165,7 +165,7 @@
     {
       "id": "CWR_11",
       "type": "radio",
-      "label": "「呢個係咩字？」\n生",
+      "label": "「呢個係咩字？」\n<span class="cwr-word">生</span>",
       "options": [
         {
           "value": "Y",
@@ -180,7 +180,7 @@
     {
       "id": "CWR_12",
       "type": "radio",
-      "label": "「呢個係咩字？」\n狗",
+      "label": "「呢個係咩字？」\n<span class="cwr-word">狗</span>",
       "options": [
         {
           "value": "Y",
@@ -195,7 +195,7 @@
     {
       "id": "CWR_13",
       "type": "radio",
-      "label": "「呢個係咩字？」\n媽",
+      "label": "「呢個係咩字？」\n<span class="cwr-word">媽</span>",
       "options": [
         {
           "value": "Y",
@@ -210,7 +210,7 @@
     {
       "id": "CWR_14",
       "type": "radio",
-      "label": "「呢個係咩字？」\n手",
+      "label": "「呢個係咩字？」\n<span class="cwr-word">手</span>",
       "options": [
         {
           "value": "Y",
@@ -225,7 +225,7 @@
     {
       "id": "CWR_15",
       "type": "radio",
-      "label": "「呢個係咩字？」\n秋",
+      "label": "「呢個係咩字？」\n<span class="cwr-word">秋</span>",
       "options": [
         {
           "value": "Y",
@@ -240,7 +240,7 @@
     {
       "id": "CWR_16",
       "type": "radio",
-      "label": "「呢個係咩字？」\n我",
+      "label": "「呢個係咩字？」\n<span class="cwr-word">我</span>",
       "options": [
         {
           "value": "Y",
@@ -255,7 +255,7 @@
     {
       "id": "CWR_17",
       "type": "radio",
-      "label": "「呢個係咩字？」\n樹",
+      "label": "「呢個係咩字？」\n<span class="cwr-word">樹</span>",
       "options": [
         {
           "value": "Y",
@@ -270,7 +270,7 @@
     {
       "id": "CWR_18",
       "type": "radio",
-      "label": "「呢個係咩字？」\n球",
+      "label": "「呢個係咩字？」\n<span class="cwr-word">球</span>",
       "options": [
         {
           "value": "Y",
@@ -285,7 +285,7 @@
     {
       "id": "CWR_19",
       "type": "radio",
-      "label": "「呢個係咩字？」\n藍",
+      "label": "「呢個係咩字？」\n<span class="cwr-word">藍</span>",
       "options": [
         {
           "value": "Y",
@@ -300,7 +300,7 @@
     {
       "id": "CWR_20",
       "type": "radio",
-      "label": "「呢個係咩字？」\n好",
+      "label": "「呢個係咩字？」\n<span class="cwr-word">好</span>",
       "options": [
         {
           "value": "Y",
@@ -315,7 +315,7 @@
     {
       "id": "CWR_21",
       "type": "radio",
-      "label": "「呢個係咩字？」\n兒",
+      "label": "「呢個係咩字？」\n<span class="cwr-word">兒</span>",
       "options": [
         {
           "value": "Y",
@@ -330,7 +330,7 @@
     {
       "id": "CWR_22",
       "type": "radio",
-      "label": "「呢個係咩字？」\n飛",
+      "label": "「呢個係咩字？」\n<span class="cwr-word">飛</span>",
       "options": [
         {
           "value": "Y",
@@ -345,7 +345,7 @@
     {
       "id": "CWR_23",
       "type": "radio",
-      "label": "「呢個係咩字？」\n多",
+      "label": "「呢個係咩字？」\n<span class="cwr-word">多</span>",
       "options": [
         {
           "value": "Y",
@@ -360,7 +360,7 @@
     {
       "id": "CWR_24",
       "type": "radio",
-      "label": "「呢個係咩字？」\n快",
+      "label": "「呢個係咩字？」\n<span class="cwr-word">快</span>",
       "options": [
         {
           "value": "Y",
@@ -375,7 +375,7 @@
     {
       "id": "CWR_25",
       "type": "radio",
-      "label": "「呢個係咩字？」\n個",
+      "label": "「呢個係咩字？」\n<span class="cwr-word">個</span>",
       "options": [
         {
           "value": "Y",
@@ -390,7 +390,7 @@
     {
       "id": "CWR_26",
       "type": "radio",
-      "label": "「呢個係咩字？」\n的",
+      "label": "「呢個係咩字？」\n<span class="cwr-word">的</span>",
       "options": [
         {
           "value": "Y",
@@ -405,7 +405,7 @@
     {
       "id": "CWR_27",
       "type": "radio",
-      "label": "「呢個係咩字？」\n蕉",
+      "label": "「呢個係咩字？」\n<span class="cwr-word">蕉</span>",
       "options": [
         {
           "value": "Y",
@@ -420,7 +420,7 @@
     {
       "id": "CWR_28",
       "type": "radio",
-      "label": "「呢個係咩字？」\n去",
+      "label": "「呢個係咩字？」\n<span class="cwr-word">去</span>",
       "options": [
         {
           "value": "Y",
@@ -435,7 +435,7 @@
     {
       "id": "CWR_29",
       "type": "radio",
-      "label": "「呢個係咩字？」\n在",
+      "label": "「呢個係咩字？」\n<span class="cwr-word">在</span>",
       "options": [
         {
           "value": "Y",
@@ -450,7 +450,7 @@
     {
       "id": "CWR_30",
       "type": "radio",
-      "label": "「呢個係咩字？」\n說",
+      "label": "「呢個係咩字？」\n<span class="cwr-word">說</span>",
       "options": [
         {
           "value": "Y",
@@ -465,7 +465,7 @@
     {
       "id": "CWR_31",
       "type": "radio",
-      "label": "「呢個係咩字？」\n香港",
+      "label": "「呢個係咩字？」\n<span class="cwr-word">香港</span>",
       "options": [
         {
           "value": "Y",
@@ -480,7 +480,7 @@
     {
       "id": "CWR_32",
       "type": "radio",
-      "label": "「呢個係咩字？」\n市場",
+      "label": "「呢個係咩字？」\n<span class="cwr-word">市場</span>",
       "options": [
         {
           "value": "Y",
@@ -495,7 +495,7 @@
     {
       "id": "CWR_33",
       "type": "radio",
-      "label": "「呢個係咩字？」\n新年",
+      "label": "「呢個係咩字？」\n<span class="cwr-word">新年</span>",
       "options": [
         {
           "value": "Y",
@@ -510,7 +510,7 @@
     {
       "id": "CWR_34",
       "type": "radio",
-      "label": "「呢個係咩字？」\n星期",
+      "label": "「呢個係咩字？」\n<span class="cwr-word">星期</span>",
       "options": [
         {
           "value": "Y",
@@ -525,7 +525,7 @@
     {
       "id": "CWR_35",
       "type": "radio",
-      "label": "「呢個係咩字？」\n耳朵",
+      "label": "「呢個係咩字？」\n<span class="cwr-word">耳朵</span>",
       "options": [
         {
           "value": "Y",
@@ -540,7 +540,7 @@
     {
       "id": "CWR_36",
       "type": "radio",
-      "label": "「呢個係咩字？」\n中午",
+      "label": "「呢個係咩字？」\n<span class="cwr-word">中午</span>",
       "options": [
         {
           "value": "Y",
@@ -555,7 +555,7 @@
     {
       "id": "CWR_37",
       "type": "radio",
-      "label": "「呢個係咩字？」\n眼睛",
+      "label": "「呢個係咩字？」\n<span class="cwr-word">眼睛</span>",
       "options": [
         {
           "value": "Y",
@@ -570,7 +570,7 @@
     {
       "id": "CWR_38",
       "type": "radio",
-      "label": "「呢個係咩字？」\n晚上",
+      "label": "「呢個係咩字？」\n<span class="cwr-word">晚上</span>",
       "options": [
         {
           "value": "Y",
@@ -585,7 +585,7 @@
     {
       "id": "CWR_39",
       "type": "radio",
-      "label": "「呢個係咩字？」\n老師",
+      "label": "「呢個係咩字？」\n<span class="cwr-word">老師</span>",
       "options": [
         {
           "value": "Y",
@@ -600,7 +600,7 @@
     {
       "id": "CWR_40",
       "type": "radio",
-      "label": "「呢個係咩字？」\n房屋",
+      "label": "「呢個係咩字？」\n<span class="cwr-word">房屋</span>",
       "options": [
         {
           "value": "Y",
@@ -615,7 +615,7 @@
     {
       "id": "CWR_41",
       "type": "radio",
-      "label": "「呢個係咩字？」\n美麗",
+      "label": "「呢個係咩字？」\n<span class="cwr-word">美麗</span>",
       "options": [
         {
           "value": "Y",
@@ -630,7 +630,7 @@
     {
       "id": "CWR_42",
       "type": "radio",
-      "label": "「呢個係咩字？」\n衣服",
+      "label": "「呢個係咩字？」\n<span class="cwr-word">衣服</span>",
       "options": [
         {
           "value": "Y",
@@ -645,7 +645,7 @@
     {
       "id": "CWR_43",
       "type": "radio",
-      "label": "「呢個係咩字？」\n鼻子",
+      "label": "「呢個係咩字？」\n<span class="cwr-word">鼻子</span>",
       "options": [
         {
           "value": "Y",
@@ -660,7 +660,7 @@
     {
       "id": "CWR_44",
       "type": "radio",
-      "label": "「呢個係咩字？」\n再見",
+      "label": "「呢個係咩字？」\n<span class="cwr-word">再見</span>",
       "options": [
         {
           "value": "Y",
@@ -675,7 +675,7 @@
     {
       "id": "CWR_45",
       "type": "radio",
-      "label": "「呢個係咩字？」\n禮物",
+      "label": "「呢個係咩字？」\n<span class="cwr-word">禮物</span>",
       "options": [
         {
           "value": "Y",
@@ -690,7 +690,7 @@
     {
       "id": "CWR_46",
       "type": "radio",
-      "label": "「呢個係咩字？」\n蜜蜂",
+      "label": "「呢個係咩字？」\n<span class="cwr-word">蜜蜂</span>",
       "options": [
         {
           "value": "Y",
@@ -705,7 +705,7 @@
     {
       "id": "CWR_47",
       "type": "radio",
-      "label": "「呢個係咩字？」\n書包",
+      "label": "「呢個係咩字？」\n<span class="cwr-word">書包</span>",
       "options": [
         {
           "value": "Y",
@@ -720,7 +720,7 @@
     {
       "id": "CWR_48",
       "type": "radio",
-      "label": "「呢個係咩字？」\n電腦",
+      "label": "「呢個係咩字？」\n<span class="cwr-word">電腦</span>",
       "options": [
         {
           "value": "Y",
@@ -735,7 +735,7 @@
     {
       "id": "CWR_49",
       "type": "radio",
-      "label": "「呢個係咩字？」\n馬路",
+      "label": "「呢個係咩字？」\n<span class="cwr-word">馬路</span>",
       "options": [
         {
           "value": "Y",
@@ -750,7 +750,7 @@
     {
       "id": "CWR_50",
       "type": "radio",
-      "label": "「呢個係咩字？」\n糖果",
+      "label": "「呢個係咩字？」\n<span class="cwr-word">糖果</span>",
       "options": [
         {
           "value": "Y",
@@ -765,7 +765,7 @@
     {
       "id": "CWR_51",
       "type": "radio",
-      "label": "「呢個係咩字？」\n你們",
+      "label": "「呢個係咩字？」\n<span class="cwr-word">你們</span>",
       "options": [
         {
           "value": "Y",
@@ -780,7 +780,7 @@
     {
       "id": "CWR_52",
       "type": "radio",
-      "label": "「呢個係咩字？」\n家庭",
+      "label": "「呢個係咩字？」\n<span class="cwr-word">家庭</span>",
       "options": [
         {
           "value": "Y",
@@ -795,7 +795,7 @@
     {
       "id": "CWR_53",
       "type": "radio",
-      "label": "「呢個係咩字？」\n飲食",
+      "label": "「呢個係咩字？」\n<span class="cwr-word">飲食</span>",
       "options": [
         {
           "value": "Y",
@@ -810,7 +810,7 @@
     {
       "id": "CWR_54",
       "type": "radio",
-      "label": "「呢個係咩字？」\n牙刷",
+      "label": "「呢個係咩字？」\n<span class="cwr-word">牙刷</span>",
       "options": [
         {
           "value": "Y",
@@ -825,7 +825,7 @@
     {
       "id": "CWR_55",
       "type": "radio",
-      "label": "「呢個係咩字？」\n海灘",
+      "label": "「呢個係咩字？」\n<span class="cwr-word">海灘</span>",
       "options": [
         {
           "value": "Y",

--- a/css/modules/survey-items.css
+++ b/css/modules/survey-items.css
@@ -48,3 +48,13 @@
     display: block;
     margin-bottom: 8px;
 }
+
+/* Specific style for Chinese Word Reading characters */
+.cwr-word {
+    font-size: 32px;
+    font-weight: bold;
+    display: inline-block;
+    margin-top: 8px;
+    color: #000;
+}
+


### PR DESCRIPTION
## Summary
- highlight Chinese Word Reading items with larger font
- add `.cwr-word` style for Chinese character emphasis

## Testing
- `grep -n "cwr-word" -n assets/tasks/ChineseWordReading.json | head`


------
https://chatgpt.com/codex/tasks/task_e_68818c4a067883278acb75fad21b5de4