### PR TITLE
Add arrow navigation buttons and keyboard shortcuts

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,8 +59,8 @@
                     </div>
                     <div id="question-container"></div>
                     <div class="survey-navigation">
-                        <button id="back-btn">返回</button>
-                        <button id="next-btn">下一題</button>
+                        <button id="back-btn" aria-label="返回">&#8592;</button>
+                        <button id="next-btn" aria-label="下一題">&#8594;</button>
                     </div>
                     <div id="debug-controls" class="hidden">
                         <button id="add-question-btn">Add Question</button>

--- a/js/modules/events.js
+++ b/js/modules/events.js
@@ -13,7 +13,20 @@ export function initializeEventListeners() {
     if (exportBtn) {
         exportBtn.addEventListener('click', exportResponsesToCsv);
     }
+    document.addEventListener('keydown', handleArrowNavigation);
     attachEntryFormListeners();
+}
+
+function handleArrowNavigation(e) {
+    const active = document.activeElement;
+    if (active && (active.tagName === 'INPUT' || active.tagName === 'TEXTAREA' || active.isContentEditable)) {
+        return;
+    }
+    if (e.key === 'ArrowLeft') {
+        navigatePage(-1);
+    } else if (e.key === 'ArrowRight') {
+        navigatePage(1);
+    }
 }
 
 let isLoadingData = false; // Flag to prevent multiple simultaneous loads


### PR DESCRIPTION
## Summary
- make navigation buttons show arrows instead of Chinese text
- allow navigating questions with keyboard arrow keys

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6881a84871888327a39619da628f65b8