### PR TITLE
Improve survey media handling

### DIFF
--- a/css/modules/survey-items.css
+++ b/css/modules/survey-items.css
@@ -105,7 +105,13 @@
 }
 
 .image-choice-option img {
-    max-width: 120px;
+    width: clamp(240px, 40vw, 100%);
     height: auto;
     margin-top: 4px;
+}
+
+/* Audio player within questions */
+.question-audio {
+    width: 100%;
+    margin-bottom: 12px;
 }

--- a/js/modules/navigation.js
+++ b/js/modules/navigation.js
@@ -86,8 +86,10 @@ export function showToc() {
         saveToLocal();
     }
     renderToc();
-    document.getElementById('top-nav').classList.add('hidden');
-    document.body.classList.remove('nav-visible');
+    topNav.classList.remove('hidden');
+    topNav.classList.add('visible');
+    document.body.classList.add('nav-visible');
+    updateInfoDisplay();
     if (state.infoDisplayInterval) {
         clearInterval(state.infoDisplayInterval);
         state.infoDisplayInterval = null;

--- a/js/modules/question.js
+++ b/js/modules/question.js
@@ -70,6 +70,14 @@ export function renderCurrentQuestion() {
         questionWrapper.appendChild(label);
     }
 
+    if (question.media && question.media.audio) {
+        const audio = document.createElement('audio');
+        audio.controls = true;
+        audio.src = `assets/${question.media.audio}`;
+        audio.classList.add('question-audio');
+        questionWrapper.appendChild(audio);
+    }
+
     // Render based on question type
     switch (question.type) {
         case 'instruction':
@@ -111,6 +119,7 @@ export function renderCurrentQuestion() {
         case 'image-choice':
             const imgGroup = document.createElement('div');
             imgGroup.classList.add('image-choice-group');
+
             question.options.forEach(opt => {
                 const labelImg = document.createElement('label');
                 labelImg.classList.add('option-label', 'answer', 'image-choice-option');


### PR DESCRIPTION
## Summary
- enlarge image choice thumbnails and support full width audio players
- render an audio element for any question that includes audio media
- show the top navigation bar on the table of contents page

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6881b394d3c08327884230216b1b4f64