### PR TITLE
Fix ERV asset naming and debug features

### DIFF
--- a/assets/tasks/ERV.json
+++ b/assets/tasks/ERV.json
@@ -145,32 +145,32 @@
       },
       "options": [
         {
-          "value": "cat",
+          "value": "opt1",
           "media": {
             "image": "images/ERV/ERV1.1.jpg"
           }
         },
         {
-          "value": "opt1",
+          "value": "opt2",
           "media": {
             "image": "images/ERV/ERV1.2.jpg"
           }
         },
         {
-          "value": "opt2",
+          "value": "opt3",
           "media": {
             "image": "images/ERV/ERV1.3.jpg"
           }
         },
         {
-          "value": "opt3",
+          "value": "opt4",
           "media": {
             "image": "images/ERV/ERV1.4.jpg"
           }
         }
       ],
       "scoring": {
-        "correctAnswer": "cat"
+        "correctAnswer": "opt1"
       }
     },
     {
@@ -182,32 +182,32 @@
       },
       "options": [
         {
-          "value": "apple",
-          "media": {
-            "image": "images/apple.png"
-          }
-        },
-        {
           "value": "opt1",
           "media": {
-            "image": "images/opt1.png"
+            "image": "images/ERV/ERV2.1.jpg"
           }
         },
         {
           "value": "opt2",
           "media": {
-            "image": "images/opt2.png"
+            "image": "images/ERV/ERV2.2.jpg"
           }
         },
         {
           "value": "opt3",
           "media": {
-            "image": "images/opt3.png"
+            "image": "images/ERV/ERV2.3.jpg"
+          }
+        },
+        {
+          "value": "opt4",
+          "media": {
+            "image": "images/ERV/ERV2.4.jpg"
           }
         }
       ],
       "scoring": {
-        "correctAnswer": "apple"
+        "correctAnswer": "opt1"
       }
     },
     {
@@ -219,32 +219,32 @@
       },
       "options": [
         {
-          "value": "balloon",
-          "media": {
-            "image": "images/balloon.png"
-          }
-        },
-        {
           "value": "opt1",
           "media": {
-            "image": "images/opt1.png"
+            "image": "images/ERV/ERV3.1.jpg"
           }
         },
         {
           "value": "opt2",
           "media": {
-            "image": "images/opt2.png"
+            "image": "images/ERV/ERV3.2.jpg"
           }
         },
         {
           "value": "opt3",
           "media": {
-            "image": "images/opt3.png"
+            "image": "images/ERV/ERV3.3.jpg"
+          }
+        },
+        {
+          "value": "opt4",
+          "media": {
+            "image": "images/ERV/ERV3.4.jpg"
           }
         }
       ],
       "scoring": {
-        "correctAnswer": "balloon"
+        "correctAnswer": "opt1"
       }
     },
     {
@@ -256,32 +256,32 @@
       },
       "options": [
         {
-          "value": "hand",
-          "media": {
-            "image": "images/hand.png"
-          }
-        },
-        {
           "value": "opt1",
           "media": {
-            "image": "images/opt1.png"
+            "image": "images/ERV/ERV4.1.jpg"
           }
         },
         {
           "value": "opt2",
           "media": {
-            "image": "images/opt2.png"
+            "image": "images/ERV/ERV4.2.jpg"
           }
         },
         {
           "value": "opt3",
           "media": {
-            "image": "images/opt3.png"
+            "image": "images/ERV/ERV4.3.jpg"
+          }
+        },
+        {
+          "value": "opt4",
+          "media": {
+            "image": "images/ERV/ERV4.4.jpg"
           }
         }
       ],
       "scoring": {
-        "correctAnswer": "hand"
+        "correctAnswer": "opt1"
       }
     },
     {
@@ -293,32 +293,32 @@
       },
       "options": [
         {
-          "value": "airplane",
-          "media": {
-            "image": "images/airplane.png"
-          }
-        },
-        {
           "value": "opt1",
           "media": {
-            "image": "images/opt1.png"
+            "image": "images/ERV/ERV5.1.jpg"
           }
         },
         {
           "value": "opt2",
           "media": {
-            "image": "images/opt2.png"
+            "image": "images/ERV/ERV5.2.jpg"
           }
         },
         {
           "value": "opt3",
           "media": {
-            "image": "images/opt3.png"
+            "image": "images/ERV/ERV5.3.jpg"
+          }
+        },
+        {
+          "value": "opt4",
+          "media": {
+            "image": "images/ERV/ERV5.4.jpg"
           }
         }
       ],
       "scoring": {
-        "correctAnswer": "airplane"
+        "correctAnswer": "opt1"
       }
     },
     {
@@ -330,32 +330,32 @@
       },
       "options": [
         {
-          "value": "bird",
-          "media": {
-            "image": "images/bird.png"
-          }
-        },
-        {
           "value": "opt1",
           "media": {
-            "image": "images/opt1.png"
+            "image": "images/ERV/ERV6.1.jpg"
           }
         },
         {
           "value": "opt2",
           "media": {
-            "image": "images/opt2.png"
+            "image": "images/ERV/ERV6.2.jpg"
           }
         },
         {
           "value": "opt3",
           "media": {
-            "image": "images/opt3.png"
+            "image": "images/ERV/ERV6.3.jpg"
+          }
+        },
+        {
+          "value": "opt4",
+          "media": {
+            "image": "images/ERV/ERV6.4.jpg"
           }
         }
       ],
       "scoring": {
-        "correctAnswer": "bird"
+        "correctAnswer": "opt1"
       }
     },
     {
@@ -367,32 +367,32 @@
       },
       "options": [
         {
-          "value": "tree",
-          "media": {
-            "image": "images/tree.png"
-          }
-        },
-        {
           "value": "opt1",
           "media": {
-            "image": "images/opt1.png"
+            "image": "images/ERV/ERV7.1.jpg"
           }
         },
         {
           "value": "opt2",
           "media": {
-            "image": "images/opt2.png"
+            "image": "images/ERV/ERV7.2.jpg"
           }
         },
         {
           "value": "opt3",
           "media": {
-            "image": "images/opt3.png"
+            "image": "images/ERV/ERV7.3.jpg"
+          }
+        },
+        {
+          "value": "opt4",
+          "media": {
+            "image": "images/ERV/ERV7.4.jpg"
           }
         }
       ],
       "scoring": {
-        "correctAnswer": "tree"
+        "correctAnswer": "opt1"
       }
     },
     {
@@ -404,32 +404,32 @@
       },
       "options": [
         {
-          "value": "table",
-          "media": {
-            "image": "images/table.png"
-          }
-        },
-        {
           "value": "opt1",
           "media": {
-            "image": "images/opt1.png"
+            "image": "images/ERV/ERV8.1.jpg"
           }
         },
         {
           "value": "opt2",
           "media": {
-            "image": "images/opt2.png"
+            "image": "images/ERV/ERV8.2.jpg"
           }
         },
         {
           "value": "opt3",
           "media": {
-            "image": "images/opt3.png"
+            "image": "images/ERV/ERV8.3.jpg"
+          }
+        },
+        {
+          "value": "opt4",
+          "media": {
+            "image": "images/ERV/ERV8.4.jpg"
           }
         }
       ],
       "scoring": {
-        "correctAnswer": "table"
+        "correctAnswer": "opt1"
       }
     },
     {
@@ -441,32 +441,32 @@
       },
       "options": [
         {
-          "value": "drinking",
-          "media": {
-            "image": "images/drinking.png"
-          }
-        },
-        {
           "value": "opt1",
           "media": {
-            "image": "images/opt1.png"
+            "image": "images/ERV/ERV9.1.jpg"
           }
         },
         {
           "value": "opt2",
           "media": {
-            "image": "images/opt2.png"
+            "image": "images/ERV/ERV9.2.jpg"
           }
         },
         {
           "value": "opt3",
           "media": {
-            "image": "images/opt3.png"
+            "image": "images/ERV/ERV9.3.jpg"
+          }
+        },
+        {
+          "value": "opt4",
+          "media": {
+            "image": "images/ERV/ERV9.4.jpg"
           }
         }
       ],
       "scoring": {
-        "correctAnswer": "drinking"
+        "correctAnswer": "opt1"
       }
     },
     {
@@ -478,32 +478,32 @@
       },
       "options": [
         {
-          "value": "frog",
-          "media": {
-            "image": "images/frog.png"
-          }
-        },
-        {
           "value": "opt1",
           "media": {
-            "image": "images/opt1.png"
+            "image": "images/ERV/ERV10.1.jpg"
           }
         },
         {
           "value": "opt2",
           "media": {
-            "image": "images/opt2.png"
+            "image": "images/ERV/ERV10.2.jpg"
           }
         },
         {
           "value": "opt3",
           "media": {
-            "image": "images/opt3.png"
+            "image": "images/ERV/ERV10.3.jpg"
+          }
+        },
+        {
+          "value": "opt4",
+          "media": {
+            "image": "images/ERV/ERV10.4.jpg"
           }
         }
       ],
       "scoring": {
-        "correctAnswer": "frog"
+        "correctAnswer": "opt1"
       }
     },
     {
@@ -515,32 +515,32 @@
       },
       "options": [
         {
-          "value": "money",
-          "media": {
-            "image": "images/money.png"
-          }
-        },
-        {
           "value": "opt1",
           "media": {
-            "image": "images/opt1.png"
+            "image": "images/ERV/ERV11.1.jpg"
           }
         },
         {
           "value": "opt2",
           "media": {
-            "image": "images/opt2.png"
+            "image": "images/ERV/ERV11.2.jpg"
           }
         },
         {
           "value": "opt3",
           "media": {
-            "image": "images/opt3.png"
+            "image": "images/ERV/ERV11.3.jpg"
+          }
+        },
+        {
+          "value": "opt4",
+          "media": {
+            "image": "images/ERV/ERV11.4.jpg"
           }
         }
       ],
       "scoring": {
-        "correctAnswer": "money"
+        "correctAnswer": "opt1"
       }
     },
     {
@@ -552,32 +552,32 @@
       },
       "options": [
         {
-          "value": "umbrella",
-          "media": {
-            "image": "images/umbrella.png"
-          }
-        },
-        {
           "value": "opt1",
           "media": {
-            "image": "images/opt1.png"
+            "image": "images/ERV/ERV12.1.jpg"
           }
         },
         {
           "value": "opt2",
           "media": {
-            "image": "images/opt2.png"
+            "image": "images/ERV/ERV12.2.jpg"
           }
         },
         {
           "value": "opt3",
           "media": {
-            "image": "images/opt3.png"
+            "image": "images/ERV/ERV12.3.jpg"
+          }
+        },
+        {
+          "value": "opt4",
+          "media": {
+            "image": "images/ERV/ERV12.4.jpg"
           }
         }
       ],
       "scoring": {
-        "correctAnswer": "umbrella"
+        "correctAnswer": "opt1"
       }
     },
     {
@@ -594,32 +594,32 @@
       },
       "options": [
         {
-          "value": "running",
-          "media": {
-            "image": "images/running.png"
-          }
-        },
-        {
           "value": "opt1",
           "media": {
-            "image": "images/opt1.png"
+            "image": "images/ERV/ERV13.1.jpg"
           }
         },
         {
           "value": "opt2",
           "media": {
-            "image": "images/opt2.png"
+            "image": "images/ERV/ERV13.2.jpg"
           }
         },
         {
           "value": "opt3",
           "media": {
-            "image": "images/opt3.png"
+            "image": "images/ERV/ERV13.3.jpg"
+          }
+        },
+        {
+          "value": "opt4",
+          "media": {
+            "image": "images/ERV/ERV13.4.jpg"
           }
         }
       ],
       "scoring": {
-        "correctAnswer": "running"
+        "correctAnswer": "opt1"
       }
     },
     {
@@ -631,32 +631,32 @@
       },
       "options": [
         {
-          "value": "window",
-          "media": {
-            "image": "images/window.png"
-          }
-        },
-        {
           "value": "opt1",
           "media": {
-            "image": "images/opt1.png"
+            "image": "images/ERV/ERV14.1.jpg"
           }
         },
         {
           "value": "opt2",
           "media": {
-            "image": "images/opt2.png"
+            "image": "images/ERV/ERV14.2.jpg"
           }
         },
         {
           "value": "opt3",
           "media": {
-            "image": "images/opt3.png"
+            "image": "images/ERV/ERV14.3.jpg"
+          }
+        },
+        {
+          "value": "opt4",
+          "media": {
+            "image": "images/ERV/ERV14.4.jpg"
           }
         }
       ],
       "scoring": {
-        "correctAnswer": "window"
+        "correctAnswer": "opt1"
       }
     },
     {
@@ -668,32 +668,32 @@
       },
       "options": [
         {
-          "value": "neck",
-          "media": {
-            "image": "images/neck.png"
-          }
-        },
-        {
           "value": "opt1",
           "media": {
-            "image": "images/opt1.png"
+            "image": "images/ERV/ERV15.1.jpg"
           }
         },
         {
           "value": "opt2",
           "media": {
-            "image": "images/opt2.png"
+            "image": "images/ERV/ERV15.2.jpg"
           }
         },
         {
           "value": "opt3",
           "media": {
-            "image": "images/opt3.png"
+            "image": "images/ERV/ERV15.3.jpg"
+          }
+        },
+        {
+          "value": "opt4",
+          "media": {
+            "image": "images/ERV/ERV15.4.jpg"
           }
         }
       ],
       "scoring": {
-        "correctAnswer": "neck"
+        "correctAnswer": "opt1"
       }
     },
     {
@@ -705,32 +705,32 @@
       },
       "options": [
         {
-          "value": "talking",
-          "media": {
-            "image": "images/talking.png"
-          }
-        },
-        {
           "value": "opt1",
           "media": {
-            "image": "images/opt1.png"
+            "image": "images/ERV/ERV16.1.jpg"
           }
         },
         {
           "value": "opt2",
           "media": {
-            "image": "images/opt2.png"
+            "image": "images/ERV/ERV16.2.jpg"
           }
         },
         {
           "value": "opt3",
           "media": {
-            "image": "images/opt3.png"
+            "image": "images/ERV/ERV16.3.jpg"
+          }
+        },
+        {
+          "value": "opt4",
+          "media": {
+            "image": "images/ERV/ERV16.4.jpg"
           }
         }
       ],
       "scoring": {
-        "correctAnswer": "talking"
+        "correctAnswer": "opt1"
       }
     },
     {
@@ -742,32 +742,32 @@
       },
       "options": [
         {
-          "value": "blue",
-          "media": {
-            "image": "images/blue.png"
-          }
-        },
-        {
           "value": "opt1",
           "media": {
-            "image": "images/opt1.png"
+            "image": "images/ERV/ERV17.1.jpg"
           }
         },
         {
           "value": "opt2",
           "media": {
-            "image": "images/opt2.png"
+            "image": "images/ERV/ERV17.2.jpg"
           }
         },
         {
           "value": "opt3",
           "media": {
-            "image": "images/opt3.png"
+            "image": "images/ERV/ERV17.3.jpg"
+          }
+        },
+        {
+          "value": "opt4",
+          "media": {
+            "image": "images/ERV/ERV17.4.jpg"
           }
         }
       ],
       "scoring": {
-        "correctAnswer": "blue"
+        "correctAnswer": "opt1"
       }
     },
     {
@@ -779,32 +779,32 @@
       },
       "options": [
         {
-          "value": "thumb",
-          "media": {
-            "image": "images/thumb.png"
-          }
-        },
-        {
           "value": "opt1",
           "media": {
-            "image": "images/opt1.png"
+            "image": "images/ERV/ERV18.1.jpg"
           }
         },
         {
           "value": "opt2",
           "media": {
-            "image": "images/opt2.png"
+            "image": "images/ERV/ERV18.2.jpg"
           }
         },
         {
           "value": "opt3",
           "media": {
-            "image": "images/opt3.png"
+            "image": "images/ERV/ERV18.3.jpg"
+          }
+        },
+        {
+          "value": "opt4",
+          "media": {
+            "image": "images/ERV/ERV18.4.jpg"
           }
         }
       ],
       "scoring": {
-        "correctAnswer": "thumb"
+        "correctAnswer": "opt1"
       }
     },
     {
@@ -816,32 +816,32 @@
       },
       "options": [
         {
-          "value": "grapes",
-          "media": {
-            "image": "images/grapes.png"
-          }
-        },
-        {
           "value": "opt1",
           "media": {
-            "image": "images/opt1.png"
+            "image": "images/ERV/ERV19.1.jpg"
           }
         },
         {
           "value": "opt2",
           "media": {
-            "image": "images/opt2.png"
+            "image": "images/ERV/ERV19.2.jpg"
           }
         },
         {
           "value": "opt3",
           "media": {
-            "image": "images/opt3.png"
+            "image": "images/ERV/ERV19.3.jpg"
+          }
+        },
+        {
+          "value": "opt4",
+          "media": {
+            "image": "images/ERV/ERV19.4.jpg"
           }
         }
       ],
       "scoring": {
-        "correctAnswer": "grapes"
+        "correctAnswer": "opt1"
       }
     },
     {
@@ -853,32 +853,32 @@
       },
       "options": [
         {
-          "value": "swimming",
-          "media": {
-            "image": "images/swimming.png"
-          }
-        },
-        {
           "value": "opt1",
           "media": {
-            "image": "images/opt1.png"
+            "image": "images/ERV/ERV20.1.jpg"
           }
         },
         {
           "value": "opt2",
           "media": {
-            "image": "images/opt2.png"
+            "image": "images/ERV/ERV20.2.jpg"
           }
         },
         {
           "value": "opt3",
           "media": {
-            "image": "images/opt3.png"
+            "image": "images/ERV/ERV20.3.jpg"
+          }
+        },
+        {
+          "value": "opt4",
+          "media": {
+            "image": "images/ERV/ERV20.4.jpg"
           }
         }
       ],
       "scoring": {
-        "correctAnswer": "swimming"
+        "correctAnswer": "opt1"
       }
     },
     {
@@ -890,32 +890,32 @@
       },
       "options": [
         {
-          "value": "circle",
-          "media": {
-            "image": "images/circle.png"
-          }
-        },
-        {
           "value": "opt1",
           "media": {
-            "image": "images/opt1.png"
+            "image": "images/ERV/ERV21.1.jpg"
           }
         },
         {
           "value": "opt2",
           "media": {
-            "image": "images/opt2.png"
+            "image": "images/ERV/ERV21.2.jpg"
           }
         },
         {
           "value": "opt3",
           "media": {
-            "image": "images/opt3.png"
+            "image": "images/ERV/ERV21.3.jpg"
+          }
+        },
+        {
+          "value": "opt4",
+          "media": {
+            "image": "images/ERV/ERV21.4.jpg"
           }
         }
       ],
       "scoring": {
-        "correctAnswer": "circle"
+        "correctAnswer": "opt1"
       }
     },
     {
@@ -927,32 +927,32 @@
       },
       "options": [
         {
-          "value": "mail",
-          "media": {
-            "image": "images/mail.png"
-          }
-        },
-        {
           "value": "opt1",
           "media": {
-            "image": "images/opt1.png"
+            "image": "images/ERV/ERV22.1.jpg"
           }
         },
         {
           "value": "opt2",
           "media": {
-            "image": "images/opt2.png"
+            "image": "images/ERV/ERV22.2.jpg"
           }
         },
         {
           "value": "opt3",
           "media": {
-            "image": "images/opt3.png"
+            "image": "images/ERV/ERV22.3.jpg"
+          }
+        },
+        {
+          "value": "opt4",
+          "media": {
+            "image": "images/ERV/ERV22.4.jpg"
           }
         }
       ],
       "scoring": {
-        "correctAnswer": "mail"
+        "correctAnswer": "opt1"
       }
     },
     {
@@ -964,32 +964,32 @@
       },
       "options": [
         {
-          "value": "hammer",
-          "media": {
-            "image": "images/hammer.png"
-          }
-        },
-        {
           "value": "opt1",
           "media": {
-            "image": "images/opt1.png"
+            "image": "images/ERV/ERV23.1.jpg"
           }
         },
         {
           "value": "opt2",
           "media": {
-            "image": "images/opt2.png"
+            "image": "images/ERV/ERV23.2.jpg"
           }
         },
         {
           "value": "opt3",
           "media": {
-            "image": "images/opt3.png"
+            "image": "images/ERV/ERV23.3.jpg"
+          }
+        },
+        {
+          "value": "opt4",
+          "media": {
+            "image": "images/ERV/ERV23.4.jpg"
           }
         }
       ],
       "scoring": {
-        "correctAnswer": "hammer"
+        "correctAnswer": "opt1"
       }
     },
     {
@@ -1001,32 +1001,32 @@
       },
       "options": [
         {
-          "value": "candle",
-          "media": {
-            "image": "images/candle.png"
-          }
-        },
-        {
           "value": "opt1",
           "media": {
-            "image": "images/opt1.png"
+            "image": "images/ERV/ERV24.1.jpg"
           }
         },
         {
           "value": "opt2",
           "media": {
-            "image": "images/opt2.png"
+            "image": "images/ERV/ERV24.2.jpg"
           }
         },
         {
           "value": "opt3",
           "media": {
-            "image": "images/opt3.png"
+            "image": "images/ERV/ERV24.3.jpg"
+          }
+        },
+        {
+          "value": "opt4",
+          "media": {
+            "image": "images/ERV/ERV24.4.jpg"
           }
         }
       ],
       "scoring": {
-        "correctAnswer": "candle"
+        "correctAnswer": "opt1"
       }
     },
     {
@@ -1043,32 +1043,32 @@
       },
       "options": [
         {
-          "value": "flag",
-          "media": {
-            "image": "images/flag.png"
-          }
-        },
-        {
           "value": "opt1",
           "media": {
-            "image": "images/opt1.png"
+            "image": "images/ERV/ERV25.1.jpg"
           }
         },
         {
           "value": "opt2",
           "media": {
-            "image": "images/opt2.png"
+            "image": "images/ERV/ERV25.2.jpg"
           }
         },
         {
           "value": "opt3",
           "media": {
-            "image": "images/opt3.png"
+            "image": "images/ERV/ERV25.3.jpg"
+          }
+        },
+        {
+          "value": "opt4",
+          "media": {
+            "image": "images/ERV/ERV25.4.jpg"
           }
         }
       ],
       "scoring": {
-        "correctAnswer": "flag"
+        "correctAnswer": "opt1"
       }
     },
     {
@@ -1080,32 +1080,32 @@
       },
       "options": [
         {
-          "value": "gate",
-          "media": {
-            "image": "images/gate.png"
-          }
-        },
-        {
           "value": "opt1",
           "media": {
-            "image": "images/opt1.png"
+            "image": "images/ERV/ERV26.1.jpg"
           }
         },
         {
           "value": "opt2",
           "media": {
-            "image": "images/opt2.png"
+            "image": "images/ERV/ERV26.2.jpg"
           }
         },
         {
           "value": "opt3",
           "media": {
-            "image": "images/opt3.png"
+            "image": "images/ERV/ERV26.3.jpg"
+          }
+        },
+        {
+          "value": "opt4",
+          "media": {
+            "image": "images/ERV/ERV26.4.jpg"
           }
         }
       ],
       "scoring": {
-        "correctAnswer": "gate"
+        "correctAnswer": "opt1"
       }
     },
     {
@@ -1117,32 +1117,32 @@
       },
       "options": [
         {
-          "value": "sad",
-          "media": {
-            "image": "images/sad.png"
-          }
-        },
-        {
           "value": "opt1",
           "media": {
-            "image": "images/opt1.png"
+            "image": "images/ERV/ERV27.1.jpg"
           }
         },
         {
           "value": "opt2",
           "media": {
-            "image": "images/opt2.png"
+            "image": "images/ERV/ERV27.2.jpg"
           }
         },
         {
           "value": "opt3",
           "media": {
-            "image": "images/opt3.png"
+            "image": "images/ERV/ERV27.3.jpg"
+          }
+        },
+        {
+          "value": "opt4",
+          "media": {
+            "image": "images/ERV/ERV27.4.jpg"
           }
         }
       ],
       "scoring": {
-        "correctAnswer": "sad"
+        "correctAnswer": "opt1"
       }
     },
     {
@@ -1154,32 +1154,32 @@
       },
       "options": [
         {
-          "value": "hopping",
-          "media": {
-            "image": "images/hopping.png"
-          }
-        },
-        {
           "value": "opt1",
           "media": {
-            "image": "images/opt1.png"
+            "image": "images/ERV/ERV28.1.jpg"
           }
         },
         {
           "value": "opt2",
           "media": {
-            "image": "images/opt2.png"
+            "image": "images/ERV/ERV28.2.jpg"
           }
         },
         {
           "value": "opt3",
           "media": {
-            "image": "images/opt3.png"
+            "image": "images/ERV/ERV28.3.jpg"
+          }
+        },
+        {
+          "value": "opt4",
+          "media": {
+            "image": "images/ERV/ERV28.4.jpg"
           }
         }
       ],
       "scoring": {
-        "correctAnswer": "hopping"
+        "correctAnswer": "opt1"
       }
     },
     {
@@ -1191,32 +1191,32 @@
       },
       "options": [
         {
-          "value": "plant",
-          "media": {
-            "image": "images/plant.png"
-          }
-        },
-        {
           "value": "opt1",
           "media": {
-            "image": "images/opt1.png"
+            "image": "images/ERV/ERV29.1.jpg"
           }
         },
         {
           "value": "opt2",
           "media": {
-            "image": "images/opt2.png"
+            "image": "images/ERV/ERV29.2.jpg"
           }
         },
         {
           "value": "opt3",
           "media": {
-            "image": "images/opt3.png"
+            "image": "images/ERV/ERV29.3.jpg"
+          }
+        },
+        {
+          "value": "opt4",
+          "media": {
+            "image": "images/ERV/ERV29.4.jpg"
           }
         }
       ],
       "scoring": {
-        "correctAnswer": "plant"
+        "correctAnswer": "opt1"
       }
     },
     {
@@ -1228,32 +1228,32 @@
       },
       "options": [
         {
-          "value": "kangaroo",
-          "media": {
-            "image": "images/kangaroo.png"
-          }
-        },
-        {
           "value": "opt1",
           "media": {
-            "image": "images/opt1.png"
+            "image": "images/ERV/ERV30.1.jpg"
           }
         },
         {
           "value": "opt2",
           "media": {
-            "image": "images/opt2.png"
+            "image": "images/ERV/ERV30.2.jpg"
           }
         },
         {
           "value": "opt3",
           "media": {
-            "image": "images/opt3.png"
+            "image": "images/ERV/ERV30.3.jpg"
+          }
+        },
+        {
+          "value": "opt4",
+          "media": {
+            "image": "images/ERV/ERV30.4.jpg"
           }
         }
       ],
       "scoring": {
-        "correctAnswer": "kangaroo"
+        "correctAnswer": "opt1"
       }
     },
     {
@@ -1265,32 +1265,32 @@
       },
       "options": [
         {
-          "value": "muffin",
-          "media": {
-            "image": "images/muffin.png"
-          }
-        },
-        {
           "value": "opt1",
           "media": {
-            "image": "images/opt1.png"
+            "image": "images/ERV/ERV31.1.jpg"
           }
         },
         {
           "value": "opt2",
           "media": {
-            "image": "images/opt2.png"
+            "image": "images/ERV/ERV31.2.jpg"
           }
         },
         {
           "value": "opt3",
           "media": {
-            "image": "images/opt3.png"
+            "image": "images/ERV/ERV31.3.jpg"
+          }
+        },
+        {
+          "value": "opt4",
+          "media": {
+            "image": "images/ERV/ERV31.4.jpg"
           }
         }
       ],
       "scoring": {
-        "correctAnswer": "muffin"
+        "correctAnswer": "opt1"
       }
     },
     {
@@ -1302,32 +1302,32 @@
       },
       "options": [
         {
-          "value": "game",
-          "media": {
-            "image": "images/game.png"
-          }
-        },
-        {
           "value": "opt1",
           "media": {
-            "image": "images/opt1.png"
+            "image": "images/ERV/ERV32.1.jpg"
           }
         },
         {
           "value": "opt2",
           "media": {
-            "image": "images/opt2.png"
+            "image": "images/ERV/ERV32.2.jpg"
           }
         },
         {
           "value": "opt3",
           "media": {
-            "image": "images/opt3.png"
+            "image": "images/ERV/ERV32.3.jpg"
+          }
+        },
+        {
+          "value": "opt4",
+          "media": {
+            "image": "images/ERV/ERV32.4.jpg"
           }
         }
       ],
       "scoring": {
-        "correctAnswer": "game"
+        "correctAnswer": "opt1"
       }
     },
     {
@@ -1339,32 +1339,32 @@
       },
       "options": [
         {
-          "value": "barn",
-          "media": {
-            "image": "images/barn.png"
-          }
-        },
-        {
           "value": "opt1",
           "media": {
-            "image": "images/opt1.png"
+            "image": "images/ERV/ERV33.1.jpg"
           }
         },
         {
           "value": "opt2",
           "media": {
-            "image": "images/opt2.png"
+            "image": "images/ERV/ERV33.2.jpg"
           }
         },
         {
           "value": "opt3",
           "media": {
-            "image": "images/opt3.png"
+            "image": "images/ERV/ERV33.3.jpg"
+          }
+        },
+        {
+          "value": "opt4",
+          "media": {
+            "image": "images/ERV/ERV33.4.jpg"
           }
         }
       ],
       "scoring": {
-        "correctAnswer": "barn"
+        "correctAnswer": "opt1"
       }
     },
     {
@@ -1376,32 +1376,32 @@
       },
       "options": [
         {
-          "value": "writing",
-          "media": {
-            "image": "images/writing.png"
-          }
-        },
-        {
           "value": "opt1",
           "media": {
-            "image": "images/opt1.png"
+            "image": "images/ERV/ERV34.1.jpg"
           }
         },
         {
           "value": "opt2",
           "media": {
-            "image": "images/opt2.png"
+            "image": "images/ERV/ERV34.2.jpg"
           }
         },
         {
           "value": "opt3",
           "media": {
-            "image": "images/opt3.png"
+            "image": "images/ERV/ERV34.3.jpg"
+          }
+        },
+        {
+          "value": "opt4",
+          "media": {
+            "image": "images/ERV/ERV34.4.jpg"
           }
         }
       ],
       "scoring": {
-        "correctAnswer": "writing"
+        "correctAnswer": "opt1"
       }
     },
     {
@@ -1413,32 +1413,32 @@
       },
       "options": [
         {
-          "value": "ring",
-          "media": {
-            "image": "images/ring.png"
-          }
-        },
-        {
           "value": "opt1",
           "media": {
-            "image": "images/opt1.png"
+            "image": "images/ERV/ERV35.1.jpg"
           }
         },
         {
           "value": "opt2",
           "media": {
-            "image": "images/opt2.png"
+            "image": "images/ERV/ERV35.2.jpg"
           }
         },
         {
           "value": "opt3",
           "media": {
-            "image": "images/opt3.png"
+            "image": "images/ERV/ERV35.3.jpg"
+          }
+        },
+        {
+          "value": "opt4",
+          "media": {
+            "image": "images/ERV/ERV35.4.jpg"
           }
         }
       ],
       "scoring": {
-        "correctAnswer": "ring"
+        "correctAnswer": "opt1"
       }
     },
     {
@@ -1450,32 +1450,32 @@
       },
       "options": [
         {
-          "value": "farmer",
-          "media": {
-            "image": "images/farmer.png"
-          }
-        },
-        {
           "value": "opt1",
           "media": {
-            "image": "images/opt1.png"
+            "image": "images/ERV/ERV36.1.jpg"
           }
         },
         {
           "value": "opt2",
           "media": {
-            "image": "images/opt2.png"
+            "image": "images/ERV/ERV36.2.jpg"
           }
         },
         {
           "value": "opt3",
           "media": {
-            "image": "images/opt3.png"
+            "image": "images/ERV/ERV36.3.jpg"
+          }
+        },
+        {
+          "value": "opt4",
+          "media": {
+            "image": "images/ERV/ERV36.4.jpg"
           }
         }
       ],
       "scoring": {
-        "correctAnswer": "farmer"
+        "correctAnswer": "opt1"
       }
     },
     {
@@ -1492,32 +1492,32 @@
       },
       "options": [
         {
-          "value": "zipper",
-          "media": {
-            "image": "images/zipper.png"
-          }
-        },
-        {
           "value": "opt1",
           "media": {
-            "image": "images/opt1.png"
+            "image": "images/ERV/ERV37.1.jpg"
           }
         },
         {
           "value": "opt2",
           "media": {
-            "image": "images/opt2.png"
+            "image": "images/ERV/ERV37.2.jpg"
           }
         },
         {
           "value": "opt3",
           "media": {
-            "image": "images/opt3.png"
+            "image": "images/ERV/ERV37.3.jpg"
+          }
+        },
+        {
+          "value": "opt4",
+          "media": {
+            "image": "images/ERV/ERV37.4.jpg"
           }
         }
       ],
       "scoring": {
-        "correctAnswer": "zipper"
+        "correctAnswer": "opt1"
       }
     },
     {
@@ -1529,32 +1529,32 @@
       },
       "options": [
         {
-          "value": "nest",
-          "media": {
-            "image": "images/nest.png"
-          }
-        },
-        {
           "value": "opt1",
           "media": {
-            "image": "images/opt1.png"
+            "image": "images/ERV/ERV38.1.jpg"
           }
         },
         {
           "value": "opt2",
           "media": {
-            "image": "images/opt2.png"
+            "image": "images/ERV/ERV38.2.jpg"
           }
         },
         {
           "value": "opt3",
           "media": {
-            "image": "images/opt3.png"
+            "image": "images/ERV/ERV38.3.jpg"
+          }
+        },
+        {
+          "value": "opt4",
+          "media": {
+            "image": "images/ERV/ERV38.4.jpg"
           }
         }
       ],
       "scoring": {
-        "correctAnswer": "nest"
+        "correctAnswer": "opt1"
       }
     },
     {
@@ -1566,32 +1566,32 @@
       },
       "options": [
         {
-          "value": "mountain",
-          "media": {
-            "image": "images/mountain.png"
-          }
-        },
-        {
           "value": "opt1",
           "media": {
-            "image": "images/opt1.png"
+            "image": "images/ERV/ERV39.1.jpg"
           }
         },
         {
           "value": "opt2",
           "media": {
-            "image": "images/opt2.png"
+            "image": "images/ERV/ERV39.2.jpg"
           }
         },
         {
           "value": "opt3",
           "media": {
-            "image": "images/opt3.png"
+            "image": "images/ERV/ERV39.3.jpg"
+          }
+        },
+        {
+          "value": "opt4",
+          "media": {
+            "image": "images/ERV/ERV39.4.jpg"
           }
         }
       ],
       "scoring": {
-        "correctAnswer": "mountain"
+        "correctAnswer": "opt1"
       }
     },
     {
@@ -1603,32 +1603,32 @@
       },
       "options": [
         {
-          "value": "horn",
-          "media": {
-            "image": "images/horn.png"
-          }
-        },
-        {
           "value": "opt1",
           "media": {
-            "image": "images/opt1.png"
+            "image": "images/ERV/ERV40.1.jpg"
           }
         },
         {
           "value": "opt2",
           "media": {
-            "image": "images/opt2.png"
+            "image": "images/ERV/ERV40.2.jpg"
           }
         },
         {
           "value": "opt3",
           "media": {
-            "image": "images/opt3.png"
+            "image": "images/ERV/ERV40.3.jpg"
+          }
+        },
+        {
+          "value": "opt4",
+          "media": {
+            "image": "images/ERV/ERV40.4.jpg"
           }
         }
       ],
       "scoring": {
-        "correctAnswer": "horn"
+        "correctAnswer": "opt1"
       }
     },
     {
@@ -1640,32 +1640,32 @@
       },
       "options": [
         {
-          "value": "pear",
-          "media": {
-            "image": "images/pear.png"
-          }
-        },
-        {
           "value": "opt1",
           "media": {
-            "image": "images/opt1.png"
+            "image": "images/ERV/ERV41.1.jpg"
           }
         },
         {
           "value": "opt2",
           "media": {
-            "image": "images/opt2.png"
+            "image": "images/ERV/ERV41.2.jpg"
           }
         },
         {
           "value": "opt3",
           "media": {
-            "image": "images/opt3.png"
+            "image": "images/ERV/ERV41.3.jpg"
+          }
+        },
+        {
+          "value": "opt4",
+          "media": {
+            "image": "images/ERV/ERV41.4.jpg"
           }
         }
       ],
       "scoring": {
-        "correctAnswer": "pear"
+        "correctAnswer": "opt1"
       }
     },
     {
@@ -1677,32 +1677,32 @@
       },
       "options": [
         {
-          "value": "yawning",
-          "media": {
-            "image": "images/yawning.png"
-          }
-        },
-        {
           "value": "opt1",
           "media": {
-            "image": "images/opt1.png"
+            "image": "images/ERV/ERV42.1.jpg"
           }
         },
         {
           "value": "opt2",
           "media": {
-            "image": "images/opt2.png"
+            "image": "images/ERV/ERV42.2.jpg"
           }
         },
         {
           "value": "opt3",
           "media": {
-            "image": "images/opt3.png"
+            "image": "images/ERV/ERV42.3.jpg"
+          }
+        },
+        {
+          "value": "opt4",
+          "media": {
+            "image": "images/ERV/ERV42.4.jpg"
           }
         }
       ],
       "scoring": {
-        "correctAnswer": "yawning"
+        "correctAnswer": "opt1"
       }
     },
     {
@@ -1714,32 +1714,32 @@
       },
       "options": [
         {
-          "value": "caterpillar",
-          "media": {
-            "image": "images/caterpillar.png"
-          }
-        },
-        {
           "value": "opt1",
           "media": {
-            "image": "images/opt1.png"
+            "image": "images/ERV/ERV43.1.jpg"
           }
         },
         {
           "value": "opt2",
           "media": {
-            "image": "images/opt2.png"
+            "image": "images/ERV/ERV43.2.jpg"
           }
         },
         {
           "value": "opt3",
           "media": {
-            "image": "images/opt3.png"
+            "image": "images/ERV/ERV43.3.jpg"
+          }
+        },
+        {
+          "value": "opt4",
+          "media": {
+            "image": "images/ERV/ERV43.4.jpg"
           }
         }
       ],
       "scoring": {
-        "correctAnswer": "caterpillar"
+        "correctAnswer": "opt1"
       }
     },
     {
@@ -1751,32 +1751,32 @@
       },
       "options": [
         {
-          "value": "chin",
-          "media": {
-            "image": "images/chin.png"
-          }
-        },
-        {
           "value": "opt1",
           "media": {
-            "image": "images/opt1.png"
+            "image": "images/ERV/ERV44.1.jpg"
           }
         },
         {
           "value": "opt2",
           "media": {
-            "image": "images/opt2.png"
+            "image": "images/ERV/ERV44.2.jpg"
           }
         },
         {
           "value": "opt3",
           "media": {
-            "image": "images/opt3.png"
+            "image": "images/ERV/ERV44.3.jpg"
+          }
+        },
+        {
+          "value": "opt4",
+          "media": {
+            "image": "images/ERV/ERV44.4.jpg"
           }
         }
       ],
       "scoring": {
-        "correctAnswer": "chin"
+        "correctAnswer": "opt1"
       }
     },
     {
@@ -1788,32 +1788,32 @@
       },
       "options": [
         {
-          "value": "pouring",
-          "media": {
-            "image": "images/pouring.png"
-          }
-        },
-        {
           "value": "opt1",
           "media": {
-            "image": "images/opt1.png"
+            "image": "images/ERV/ERV45.1.jpg"
           }
         },
         {
           "value": "opt2",
           "media": {
-            "image": "images/opt2.png"
+            "image": "images/ERV/ERV45.2.jpg"
           }
         },
         {
           "value": "opt3",
           "media": {
-            "image": "images/opt3.png"
+            "image": "images/ERV/ERV45.3.jpg"
+          }
+        },
+        {
+          "value": "opt4",
+          "media": {
+            "image": "images/ERV/ERV45.4.jpg"
           }
         }
       ],
       "scoring": {
-        "correctAnswer": "pouring"
+        "correctAnswer": "opt1"
       }
     },
     {
@@ -1825,32 +1825,32 @@
       },
       "options": [
         {
-          "value": "decorated",
-          "media": {
-            "image": "images/decorated.png"
-          }
-        },
-        {
           "value": "opt1",
           "media": {
-            "image": "images/opt1.png"
+            "image": "images/ERV/ERV46.1.jpg"
           }
         },
         {
           "value": "opt2",
           "media": {
-            "image": "images/opt2.png"
+            "image": "images/ERV/ERV46.2.jpg"
           }
         },
         {
           "value": "opt3",
           "media": {
-            "image": "images/opt3.png"
+            "image": "images/ERV/ERV46.3.jpg"
+          }
+        },
+        {
+          "value": "opt4",
+          "media": {
+            "image": "images/ERV/ERV46.4.jpg"
           }
         }
       ],
       "scoring": {
-        "correctAnswer": "decorated"
+        "correctAnswer": "opt1"
       }
     },
     {
@@ -1862,32 +1862,32 @@
       },
       "options": [
         {
-          "value": "triangle",
-          "media": {
-            "image": "images/triangle.png"
-          }
-        },
-        {
           "value": "opt1",
           "media": {
-            "image": "images/opt1.png"
+            "image": "images/ERV/ERV47.1.jpg"
           }
         },
         {
           "value": "opt2",
           "media": {
-            "image": "images/opt2.png"
+            "image": "images/ERV/ERV47.2.jpg"
           }
         },
         {
           "value": "opt3",
           "media": {
-            "image": "images/opt3.png"
+            "image": "images/ERV/ERV47.3.jpg"
+          }
+        },
+        {
+          "value": "opt4",
+          "media": {
+            "image": "images/ERV/ERV47.4.jpg"
           }
         }
       ],
       "scoring": {
-        "correctAnswer": "triangle"
+        "correctAnswer": "opt1"
       }
     },
     {
@@ -1899,32 +1899,32 @@
       },
       "options": [
         {
-          "value": "desk",
-          "media": {
-            "image": "images/desk.png"
-          }
-        },
-        {
           "value": "opt1",
           "media": {
-            "image": "images/opt1.png"
+            "image": "images/ERV/ERV48.1.jpg"
           }
         },
         {
           "value": "opt2",
           "media": {
-            "image": "images/opt2.png"
+            "image": "images/ERV/ERV48.2.jpg"
           }
         },
         {
           "value": "opt3",
           "media": {
-            "image": "images/opt3.png"
+            "image": "images/ERV/ERV48.3.jpg"
+          }
+        },
+        {
+          "value": "opt4",
+          "media": {
+            "image": "images/ERV/ERV48.4.jpg"
           }
         }
       ],
       "scoring": {
-        "correctAnswer": "desk"
+        "correctAnswer": "opt1"
       }
     },
     {

--- a/css/modules/pages.css
+++ b/css/modules/pages.css
@@ -163,6 +163,12 @@
     color: #666;
 }
 
+#question-id-display {
+    font-size: 14px;
+    color: #999;
+    margin-top: 4px;
+}
+
 #timer {
     font-size: 20px;
     font-weight: bold;

--- a/css/modules/survey-items.css
+++ b/css/modules/survey-items.css
@@ -123,6 +123,11 @@
     filter: brightness(0.9);
 }
 
+/* Highlight correct option in debug mode */
+.correct-option {
+    outline: 3px dashed red;
+}
+
 /* Audio player within questions */
 .question-audio {
     width: 100%;

--- a/index.html
+++ b/index.html
@@ -55,6 +55,7 @@
                     <div class="survey-header">
                         <h2 id="current-section-display"></h2>
                         <p id="page-info"></p>
+                        <p id="question-id-display" class="question-id"></p>
                         <div id="timer"></div>
                     </div>
                     <div id="question-container"></div>

--- a/js/modules/debug.js
+++ b/js/modules/debug.js
@@ -7,13 +7,22 @@ export function initializeDebug() {
     const addBtn = document.getElementById('add-question-btn');
 
     if (trigger) {
-        trigger.addEventListener('click', () => {
+        trigger.addEventListener('click', (e) => {
+            if (state.debugMode && e.ctrlKey) {
+                state.debugMode = false;
+                document.body.classList.remove('debug-mode');
+                if (controls) controls.classList.add('hidden');
+                renderCurrentQuestion();
+                logDebug('Debug mode disabled');
+                return;
+            }
             const pwd = prompt('Enter debug password');
             if (pwd === 'ks2.0') {
                 state.debugMode = true;
                 document.body.classList.add('debug-mode');
                 if (controls) controls.classList.remove('hidden');
                 logDebug('Debug mode enabled');
+                renderCurrentQuestion();
             }
         });
     }

--- a/js/modules/question.js
+++ b/js/modules/question.js
@@ -33,6 +33,7 @@ function formatLabel(label) {
 const questionContainer = document.getElementById('question-container');
 const currentSectionDisplay = document.getElementById('current-section-display');
 const pageInfo = document.getElementById('page-info');
+const questionIdDisplay = document.getElementById('question-id-display');
 
 export function renderCurrentQuestion() {
     const section = state.surveySections[state.currentSectionId];
@@ -57,6 +58,9 @@ export function renderCurrentQuestion() {
     // Update header
     currentSectionDisplay.textContent = section.title;
     pageInfo.textContent = `第 ${state.currentPage + 1} 頁，共 ${section.questions.length} 頁`;
+    if (questionIdDisplay) {
+        questionIdDisplay.textContent = question.id;
+    }
 
     // Render the question itself
     const questionWrapper = document.createElement('div');
@@ -100,6 +104,9 @@ export function renderCurrentQuestion() {
             question.options.forEach(opt => {
                 const labelEl = document.createElement('label');
                 labelEl.classList.add('option-label', 'answer');
+                if (state.debugMode && question.scoring && question.scoring.correctAnswer === opt.value) {
+                    labelEl.classList.add('correct-option');
+                }
                 const radio = document.createElement('input');
                 radio.type = 'radio';
                 radio.name = question.id;
@@ -123,6 +130,9 @@ export function renderCurrentQuestion() {
             question.options.forEach(opt => {
                 const labelImg = document.createElement('label');
                 labelImg.classList.add('option-label', 'answer', 'image-choice-option');
+                if (state.debugMode && question.scoring && question.scoring.correctAnswer === opt.value) {
+                    labelImg.classList.add('correct-option');
+                }
                 const radioImg = document.createElement('input');
                 radioImg.type = 'radio';
                 radioImg.name = question.id;


### PR DESCRIPTION
## Summary
- standardize ERV task option values and image names
- add question id display on survey page
- show correct answers while in debug mode
- allow Ctrl+click on debug square to disable debug

## Testing
- `node --version`


------
https://chatgpt.com/codex/tasks/task_e_6881befa15dc8327bcb56448557b7377