### PR TITLE
Implement debug info for ERV termination

### DIFF
--- a/css/modules/survey-items.css
+++ b/css/modules/survey-items.css
@@ -128,3 +128,13 @@
     width: 100%;
     margin-bottom: 12px;
 }
+
+.debug-info {
+    display: none;
+    font-size: 12px;
+    color: #c00;
+}
+
+body.debug-mode .debug-info {
+    display: block;
+}

--- a/js/modules/navigation.js
+++ b/js/modules/navigation.js
@@ -60,6 +60,17 @@ export function navigatePage(direction) {
         }
     }
 
+    if (direction > 0 && state.pendingTermination && state.pendingTermination.id === question.id) {
+        if (!state.pendingTermination.allowNext) {
+            state.completionTimes[state.currentSectionId] = new Date().toISOString();
+            saveToLocal();
+            showToc();
+            state.pendingTermination = null;
+            return;
+        }
+        state.pendingTermination = null;
+    }
+
     if (newPage < 0) {
         showToc();
     } else if (newPage >= 0 && newPage < section.questions.length) {

--- a/js/modules/question.js
+++ b/js/modules/question.js
@@ -1,4 +1,5 @@
 import { state } from './state.js';
+import { evaluateTermination } from './terminations.js';
 
 function formatLabel(label) {
     if (typeof label === 'string') {
@@ -47,6 +48,18 @@ export function renderCurrentQuestion() {
         return;
     }
 
+    const terminationInfo = evaluateTermination(section.id, question.id);
+    if (terminationInfo) {
+        state.pendingTermination = terminationInfo;
+    } else {
+        state.pendingTermination = null;
+    }
+
+    let labelText = terminationInfo ? terminationInfo.message : question.label;
+    if (terminationInfo && state.debugMode && terminationInfo.debugText) {
+        labelText += `<br><span class="debug-info">${terminationInfo.debugText}</span>`;
+    }
+
     if (!state.viewedQuestions) {
         state.viewedQuestions = {};
     }
@@ -62,11 +75,11 @@ export function renderCurrentQuestion() {
     const questionWrapper = document.createElement('div');
     questionWrapper.className = 'question';
 
-    if (question.label) {
+    if (labelText) {
         const label = document.createElement('label');
         label.htmlFor = question.id;
         label.classList.add('attention', 'question-label');
-        label.innerHTML = formatLabel(question.label);
+        label.innerHTML = formatLabel(labelText);
         questionWrapper.appendChild(label);
     }
 

--- a/js/modules/state.js
+++ b/js/modules/state.js
@@ -17,7 +17,8 @@ export const state = {
     viewedQuestions: {},
     completed: false,
     infoDisplayInterval: null,
-    debugMode: false
+    debugMode: false,
+    pendingTermination: null
 };
 
 export function formatTimestamp(date) {

--- a/js/modules/terminations.js
+++ b/js/modules/terminations.js
@@ -1,0 +1,58 @@
+export const terminationRules = {
+    erv: [
+        {
+            terminationId: 'ERV_Ter1',
+            startId: 'ERV_1',
+            endId: 'ERV_12',
+            minScore: 5
+        },
+        {
+            terminationId: 'ERV_Ter2',
+            startId: 'ERV_13',
+            endId: 'ERV_24',
+            minScore: 5
+        },
+        {
+            terminationId: 'ERV_Ter3',
+            startId: 'ERV_25',
+            endId: 'ERV_36',
+            minScore: 5
+        }
+    ]
+};
+
+import { state, logDebug } from './state.js';
+
+function calculateScore(sectionId, startId, endId) {
+    const section = state.surveySections[sectionId];
+    if (!section || !section.questions) return 0;
+    const startIndex = section.questions.findIndex(q => q.id === startId);
+    const endIndex = section.questions.findIndex(q => q.id === endId);
+    if (startIndex === -1 || endIndex === -1) return 0;
+    let score = 0;
+    for (let i = startIndex; i <= endIndex; i++) {
+        const q = section.questions[i];
+        if (!q || !q.scoring) continue;
+        const resp = state.userResponses[q.id];
+        if (resp !== undefined && resp === q.scoring.correctAnswer) {
+            score += 1;
+        }
+    }
+    return score;
+}
+
+export function evaluateTermination(sectionId, questionId) {
+    const rules = terminationRules[sectionId];
+    if (!rules) return null;
+    const rule = rules.find(r => r.terminationId === questionId);
+    if (!rule) return null;
+    const total = calculateScore(sectionId, rule.startId, rule.endId);
+    const allowNext = total >= rule.minScore;
+    const needed = allowNext ? 0 : rule.minScore - total;
+    const debugText = `Score ${total}/${rule.minScore}. Need ${needed} more.`;
+    logDebug(`evaluateTermination for ${sectionId}: ${debugText}`);
+    const message = allowNext
+        ? '該部分得分多於 4 分，請按此繼續測試。'
+        : '該部分得分少於 5 分，該測試已完成，按此結束該測試。';
+    return { id: questionId, allowNext, message, debugText };
+}


### PR DESCRIPTION
## Summary
- log termination rule evaluations with score details
- show termination score info during debug mode
- style debug-info span for visibility

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6881c09d35a08327870a4d6a97966f48