### PR TITLE
Enhance Math Pattern option layout

### DIFF
--- a/css/modules/survey-items.css
+++ b/css/modules/survey-items.css
@@ -143,3 +143,31 @@
     width: 100%;
     margin-bottom: 12px;
 }
+
+/* Generic radio group layout */
+.radio-group {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+/* Larger, centered choices for Math Pattern task */
+[data-section-id="mathpattern"] .radio-group {
+    flex-direction: row;
+    justify-content: center;
+    gap: 24px;
+    margin-top: 20px;
+}
+
+[data-section-id="mathpattern"] .radio-group .option-label {
+    font-size: 36px;
+    font-weight: bold;
+    color: #333;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+[data-section-id="mathpattern"] .radio-group input[type="radio"] {
+    transform: scale(1.5);
+}

--- a/js/modules/question.js
+++ b/js/modules/question.js
@@ -159,6 +159,7 @@ export function renderCurrentQuestion() {
             break;
         case 'radio':
             const radioGroup = document.createElement('div');
+            radioGroup.classList.add('radio-group');
             question.options.forEach(opt => {
                 const labelEl = document.createElement('label');
                 labelEl.classList.add('option-label', 'answer');


### PR DESCRIPTION
## Summary
- add `radio-group` class when rendering radio questions
- style Math Pattern radios to use large, horizontal layout

## Testing
- `jp2a --width=80 screenshot.jpg | head -n 20` *(fails: command not found before install)*


------
https://chatgpt.com/codex/tasks/task_e_6881c744237083279d5ae12447ac9e07