### PR TITLE
Add CM termination scoring

### DIFF
--- a/assets/tasks/CM.json
+++ b/assets/tasks/CM.json
@@ -42,7 +42,10 @@
           "value": "N",
           "label": "N"
         }
-      ]
+      ],
+      "scoring": {
+        "correctAnswer": "Y"
+      }
     },
     {
       "id": "CM_P2a",
@@ -65,12 +68,15 @@
           "value": "N",
           "label": "N"
         }
-      ]
+      ],
+      "scoring": {
+        "correctAnswer": "Y"
+      }
     },
     {
       "id": "CM_ins3",
       "type": "instruction",
-      "label":{
+      "label": {
         "zh": "記錄規則：\n必須標準答案才能比分。\n請勿在現場教導他們相關知識。\n\n提示語：\n「我哋而家正式開始，我唔會再比提示同埋答案你。」\nLet's start.",
         "orange_text": "Let's start.",
         "emphasize": "請勿在現場教導他們相關知識。",
@@ -98,7 +104,10 @@
           "value": "N",
           "label": "N"
         }
-      ]
+      ],
+      "scoring": {
+        "correctAnswer": "Y"
+      }
     },
     {
       "id": "CM_2a",
@@ -121,7 +130,10 @@
           "value": "N",
           "label": "N"
         }
-      ]
+      ],
+      "scoring": {
+        "correctAnswer": "Y"
+      }
     },
     {
       "id": "CM_3a",
@@ -144,7 +156,10 @@
           "value": "N",
           "label": "N"
         }
-      ]
+      ],
+      "scoring": {
+        "correctAnswer": "Y"
+      }
     },
     {
       "id": "CM_4a",
@@ -167,7 +182,10 @@
           "value": "N",
           "label": "N"
         }
-      ]
+      ],
+      "scoring": {
+        "correctAnswer": "Y"
+      }
     },
     {
       "id": "CM_5a",
@@ -190,7 +208,10 @@
           "value": "N",
           "label": "N"
         }
-      ]
+      ],
+      "scoring": {
+        "correctAnswer": "Y"
+      }
     },
     {
       "id": "CM_6a",
@@ -213,7 +234,10 @@
           "value": "N",
           "label": "N"
         }
-      ]
+      ],
+      "scoring": {
+        "correctAnswer": "Y"
+      }
     },
     {
       "id": "CM_7a",
@@ -236,7 +260,10 @@
           "value": "N",
           "label": "N"
         }
-      ]
+      ],
+      "scoring": {
+        "correctAnswer": "Y"
+      }
     },
     {
       "id": "CM_Ter1",
@@ -264,7 +291,10 @@
           "value": "N",
           "label": "N"
         }
-      ]
+      ],
+      "scoring": {
+        "correctAnswer": "Y"
+      }
     },
     {
       "id": "CM_9a",
@@ -287,7 +317,10 @@
           "value": "N",
           "label": "N"
         }
-      ]
+      ],
+      "scoring": {
+        "correctAnswer": "Y"
+      }
     },
     {
       "id": "CM_10a",
@@ -310,7 +343,10 @@
           "value": "N",
           "label": "N"
         }
-      ]
+      ],
+      "scoring": {
+        "correctAnswer": "Y"
+      }
     },
     {
       "id": "CM_11a",
@@ -333,7 +369,10 @@
           "value": "N",
           "label": "N"
         }
-      ]
+      ],
+      "scoring": {
+        "correctAnswer": "Y"
+      }
     },
     {
       "id": "CM_12a",
@@ -356,7 +395,10 @@
           "value": "N",
           "label": "N"
         }
-      ]
+      ],
+      "scoring": {
+        "correctAnswer": "Y"
+      }
     },
     {
       "id": "CM_Ter2",
@@ -384,7 +426,10 @@
           "value": "N",
           "label": "N"
         }
-      ]
+      ],
+      "scoring": {
+        "correctAnswer": "Y"
+      }
     },
     {
       "id": "CM_14a",
@@ -407,7 +452,10 @@
           "value": "N",
           "label": "N"
         }
-      ]
+      ],
+      "scoring": {
+        "correctAnswer": "Y"
+      }
     },
     {
       "id": "CM_15a",
@@ -430,7 +478,10 @@
           "value": "N",
           "label": "N"
         }
-      ]
+      ],
+      "scoring": {
+        "correctAnswer": "Y"
+      }
     },
     {
       "id": "CM_16a",
@@ -453,7 +504,10 @@
           "value": "N",
           "label": "N"
         }
-      ]
+      ],
+      "scoring": {
+        "correctAnswer": "Y"
+      }
     },
     {
       "id": "CM_17a",
@@ -476,7 +530,10 @@
           "value": "N",
           "label": "N"
         }
-      ]
+      ],
+      "scoring": {
+        "correctAnswer": "Y"
+      }
     },
     {
       "id": "CM_Ter3",
@@ -504,7 +561,10 @@
           "value": "N",
           "label": "N"
         }
-      ]
+      ],
+      "scoring": {
+        "correctAnswer": "Y"
+      }
     },
     {
       "id": "CM_19a",
@@ -527,7 +587,10 @@
           "value": "N",
           "label": "N"
         }
-      ]
+      ],
+      "scoring": {
+        "correctAnswer": "Y"
+      }
     },
     {
       "id": "CM_20a",
@@ -550,7 +613,10 @@
           "value": "N",
           "label": "N"
         }
-      ]
+      ],
+      "scoring": {
+        "correctAnswer": "Y"
+      }
     },
     {
       "id": "CM_21a",
@@ -573,7 +639,10 @@
           "value": "N",
           "label": "N"
         }
-      ]
+      ],
+      "scoring": {
+        "correctAnswer": "Y"
+      }
     },
     {
       "id": "CM_22a",
@@ -596,7 +665,10 @@
           "value": "N",
           "label": "N"
         }
-      ]
+      ],
+      "scoring": {
+        "correctAnswer": "Y"
+      }
     },
     {
       "id": "CM_Ter4",
@@ -624,7 +696,10 @@
           "value": "N",
           "label": "N"
         }
-      ]
+      ],
+      "scoring": {
+        "correctAnswer": "Y"
+      }
     },
     {
       "id": "CM_24a",
@@ -647,7 +722,10 @@
           "value": "N",
           "label": "N"
         }
-      ]
+      ],
+      "scoring": {
+        "correctAnswer": "Y"
+      }
     },
     {
       "id": "CM_25a",
@@ -670,7 +748,10 @@
           "value": "N",
           "label": "N"
         }
-      ]
+      ],
+      "scoring": {
+        "correctAnswer": "Y"
+      }
     },
     {
       "id": "CM_26a",
@@ -693,7 +774,10 @@
           "value": "N",
           "label": "N"
         }
-      ]
+      ],
+      "scoring": {
+        "correctAnswer": "Y"
+      }
     },
     {
       "id": "CM_27a",
@@ -716,7 +800,10 @@
           "value": "N",
           "label": "N"
         }
-      ]
+      ],
+      "scoring": {
+        "correctAnswer": "Y"
+      }
     },
     {
       "id": "CM_S5",
@@ -737,7 +824,10 @@
           "value": "done",
           "label": "已完成"
         }
-      ]
+      ],
+      "scoring": {
+        "correctAnswer": "Y"
+      }
     }
   ]
 }

--- a/js/modules/question.js
+++ b/js/modules/question.js
@@ -5,13 +5,14 @@ const debugInfoEl = document.getElementById('debug-info');
 
 function updateDebugInfo(questionId) {
     if (!debugInfoEl) return;
-    if (!state.debugMode || state.currentSectionId !== 'erv') {
+    const sectionId = state.currentSectionId;
+    if (!state.debugMode || (sectionId !== 'erv' && sectionId !== 'cm')) {
         debugInfoEl.textContent = '';
         return;
     }
 
-    const rules = terminationRules['erv'];
-    const section = state.surveySections['erv'];
+    const rules = terminationRules[sectionId];
+    const section = state.surveySections[sectionId];
     if (!rules || !section) {
         debugInfoEl.textContent = '';
         return;
@@ -39,10 +40,16 @@ function updateDebugInfo(questionId) {
         return;
     }
 
-    const score = calculateScore('erv', currentRule.startId, currentRule.endId);
+    const score = calculateScore(sectionId, currentRule.startId, currentRule.endId);
     const needed = currentRule.minScore - score;
     const message = needed > 0 ? `還需要 ${needed} 分` : '已達標';
-    debugInfoEl.textContent = `ERV 分數：${score} / ${currentRule.minScore}，${message}`;
+    if (sectionId === 'erv') {
+        debugInfoEl.textContent = `ERV 分數：${score} / ${currentRule.minScore}，${message}`;
+    } else {
+        const partMatch = /CM_(?:Ter|S)(\d+)/i.exec(currentRule.terminationId);
+        const part = partMatch ? partMatch[1] : '';
+        debugInfoEl.textContent = `CM 第 ${part} 部分分數：${score} / ${currentRule.minScore}，${message}`;
+    }
 }
 
 function formatLabel(label) {

--- a/js/modules/terminations.js
+++ b/js/modules/terminations.js
@@ -18,6 +18,38 @@ export const terminationRules = {
             endId: 'ERV_36',
             minScore: 5
         }
+    ],
+    cm: [
+        {
+            terminationId: 'CM_Ter1',
+            startId: 'CM_1',
+            endId: 'CM_7',
+            minScore: 4
+        },
+        {
+            terminationId: 'CM_Ter2',
+            startId: 'CM_8',
+            endId: 'CM_12',
+            minScore: 4
+        },
+        {
+            terminationId: 'CM_Ter3',
+            startId: 'CM_13',
+            endId: 'CM_17',
+            minScore: 4
+        },
+        {
+            terminationId: 'CM_Ter4',
+            startId: 'CM_18',
+            endId: 'CM_22',
+            minScore: 4
+        },
+        {
+            terminationId: 'CM_S5',
+            startId: 'CM_23',
+            endId: 'CM_27',
+            minScore: 0
+        }
     ]
 };
 
@@ -48,8 +80,21 @@ export function evaluateTermination(sectionId, questionId) {
     if (!rule) return null;
     const total = calculateScore(sectionId, rule.startId, rule.endId);
     const allowNext = total >= rule.minScore;
-    const message = allowNext
-        ? '該部分得分多於 4 分，請按此繼續測試。'
-        : '該部分得分少於 5 分，該測試已完成，按此結束該測試。';
+    let message;
+    if (sectionId === 'cm') {
+        const partMatch = /CM_(?:Ter|S)(\d+)/i.exec(rule.terminationId);
+        const part = partMatch ? partMatch[1] : '';
+        if (rule.terminationId === 'CM_S5') {
+            message = `Part ${part} 得分：${total}`;
+        } else if (allowNext) {
+            message = `Part ${part} 得分：${total}\n再按右下方箭頭（➜）進入下一環節。`;
+        } else {
+            message = `Part ${part} 得分：${total}\n該測試已完成，按此結束該測試。`;
+        }
+    } else {
+        message = allowNext
+            ? '該部分得分多於 4 分，請按此繼續測試。'
+            : '該部分得分少於 5 分，該測試已完成，按此結束該測試。';
+    }
     return { id: questionId, allowNext, message };
 }


### PR DESCRIPTION
## Summary
- add scoring metadata for CM questions
- implement CM termination rules with scoring
- show part scores in CM termination screens
- show CM required score in debug view

## Testing
- `node -e "JSON.parse(require('fs').readFileSync('assets/tasks/CM.json','utf8'))"`

------
https://chatgpt.com/codex/tasks/task_e_6881ce5409f48327820e1e85a52f1582