### PR TITLE
Add timer-based SYM & NONSYM sections

### DIFF
--- a/assets/tasks/NONSYM.json
+++ b/assets/tasks/NONSYM.json
@@ -1,12 +1,15 @@
 {
   "id": "nonsym",
-  "title": "非符號關係",
+  "title": "非符號數量比較",
+  "timer": 120,
   "questions": [
-    {
-      "id": "nonsym_q1",
-      "type": "text",
-      "label": "這是一個非符號關係的佔位問題。",
-      "required": true
-    }
+    {"id": "NONSYM_ins1", "type": "instruction", "label": "此測驗採用計時方式，小朋友需在兩分鐘內盡量答完。\n\u300c你睇吓啲點點，話俾我聽邊一格有多啲點點。\u300d"},
+    {"id": "NONSYM_S1", "type": "image-choice", "label": "邊格有多啲點點？", "options": [{"value":"A","label":"左邊"},{"value":"B","label":"右邊"}], "scoring":{"correctAnswer":"A"}},
+    {"id": "NONSYM_ins2", "type": "instruction", "label": "做得好好，跟住會計時兩分鐘，你試下好似啱啱咁，好快咁指俾我睇邊個多啲點點，準備好未?"},
+    {"id": "NONSYM_1", "type": "image-choice", "label": "非符號數量比較", "options": [{"value":"left","label":"左邊"},{"value":"right","label":"右邊"}], "scoring":{"correctAnswer":"right"}},
+    {"id": "NONSYM_2", "type": "image-choice", "label": "非符號數量比較", "options": [{"value":"left","label":"左邊"},{"value":"right","label":"右邊"}], "scoring":{"correctAnswer":"left"}},
+    {"id": "NONSYM_timeout", "type": "instruction", "label": "時間到／已完成，請進行下一部分。"},
+    {"id": "NONSYM_Date", "type": "text", "label": "完成日期："},
+    {"id": "NONSYM_Com", "type": "radio", "label": "已完成", "options": [{"value":"done","label":"已完成"}]}
   ]
 }

--- a/assets/tasks/SYM.json
+++ b/assets/tasks/SYM.json
@@ -1,12 +1,18 @@
 {
   "id": "sym",
-  "title": "符號關係",
+  "title": "符號數字比較",
+  "timer": 120,
   "questions": [
-    {
-      "id": "sym_q1",
-      "type": "text",
-      "label": "這是一個符號關係的佔位問題。",
-      "required": true
-    }
+    {"id": "SYM_Cover", "type": "instruction", "label": "Symbolic \n\n確認進入測試請按右下方箭頭（➜）"},
+    {"id": "SYM_ins1", "type": "instruction", "label": "此測驗採用計時方式，小朋友需在兩分鐘內盡量答完。\n\n\u300c你睇吓啲數字，話俾我聽邊一個數字比較大?\u300d"},
+    {"id": "SYM_S1", "type": "image-choice", "label": "邊個大啲？1定係7？", "options": [{"value":"1","label":"1"},{"value":"7","label":"7"}], "scoring":{"correctAnswer":"7"}},
+    {"id": "SYM_S2", "type": "image-choice", "label": "邊個大啲？8定係2？", "options": [{"value":"8","label":"8"},{"value":"2","label":"2"}], "scoring":{"correctAnswer":"8"}},
+    {"id": "SYM_ins2", "type": "instruction", "label": "做得好，跟住會計時兩分鐘，你試下好似啱啱咁，好快咁指俾我睇邊個數字大啲，準備好就開始啦。"},
+    {"id": "SYM_1", "type": "image-choice", "label": "數字大小比較測試", "options": [{"value":"5","label":"5"},{"value":"1","label":"1"}], "scoring":{"correctAnswer":"5"}},
+    {"id": "SYM_2", "type": "image-choice", "label": "數字大小比較測試", "options": [{"value":"3","label":"3"},{"value":"9","label":"9"}], "scoring":{"correctAnswer":"9"}},
+    {"id": "SYM_3", "type": "image-choice", "label": "數字大小比較測試", "options": [{"value":"4","label":"4"},{"value":"6","label":"6"}], "scoring":{"correctAnswer":"6"}},
+    {"id": "SYM_timeout", "type": "instruction", "label": "時間到／已完成，請進行下一部分。"},
+    {"id": "SYM_Date", "type": "text", "label": "完成日期："},
+    {"id": "SYM_Com", "type": "radio", "label": "已完成", "options": [{"value":"done","label":"已完成"}]}
   ]
 }

--- a/css/modules/pages.css
+++ b/css/modules/pages.css
@@ -170,10 +170,15 @@
 }
 
 #timer {
-    font-size: 20px;
+    font-size: 28px;
     font-weight: bold;
-    color: #2b3990;
+    font-family: 'Courier New', monospace;
+    background: #222;
+    color: #0f0;
+    padding: 4px 8px;
+    border-radius: 4px;
     margin-top: 10px;
+    display: inline-block;
 }
 
 #question-container {

--- a/js/modules/question.js
+++ b/js/modules/question.js
@@ -1,5 +1,7 @@
 import { state } from './state.js';
 import { evaluateTermination, terminationRules, calculateScore } from './terminations.js';
+import { navigatePage } from './navigation.js';
+import { isTimerRunning } from './timer.js';
 
 const debugInfoEl = document.getElementById('debug-info');
 
@@ -199,6 +201,9 @@ export function renderCurrentQuestion() {
                 radioGroup.appendChild(labelEl);
             });
             questionWrapper.appendChild(radioGroup);
+            if (isTimerRunning() && state.autoNext) {
+                radioGroup.addEventListener('change', () => navigatePage(1));
+            }
             break;
         case 'image-choice':
             const imgGroup = document.createElement('div');
@@ -226,6 +231,9 @@ export function renderCurrentQuestion() {
                 imgGroup.appendChild(labelImg);
             });
             questionWrapper.appendChild(imgGroup);
+            if (isTimerRunning() && state.autoNext) {
+                imgGroup.addEventListener('change', () => navigatePage(1));
+            }
             break;
         // Add more cases for 'select', 'radio', 'checkbox', etc. here
         default:

--- a/js/modules/state.js
+++ b/js/modules/state.js
@@ -18,7 +18,9 @@ export const state = {
     completed: false,
     infoDisplayInterval: null,
     debugMode: false,
-    pendingTermination: null
+    pendingTermination: null,
+    timerSection: null,
+    autoNext: false
 };
 
 export function formatTimestamp(date) {

--- a/js/modules/timer.js
+++ b/js/modules/timer.js
@@ -1,0 +1,52 @@
+export const timerState = {
+    remaining: 0,
+    interval: null,
+    callback: null,
+    running: false
+};
+
+const timerEl = document.getElementById('timer');
+
+function formatTime(sec) {
+    const m = String(Math.floor(sec / 60)).padStart(2, '0');
+    const s = String(sec % 60).padStart(2, '0');
+    return `${m}:${s}`;
+}
+
+function updateDisplay() {
+    if (timerEl) {
+        timerEl.textContent = formatTime(timerState.remaining);
+    }
+}
+
+export function startTimer(seconds, cb) {
+    clearInterval(timerState.interval);
+    timerState.remaining = seconds;
+    timerState.callback = cb;
+    timerState.running = true;
+    updateDisplay();
+    timerState.interval = setInterval(() => {
+        timerState.remaining--;
+        if (timerState.remaining <= 0) {
+            stopTimer();
+            if (typeof timerState.callback === 'function') {
+                timerState.callback();
+            }
+        }
+        updateDisplay();
+    }, 1000);
+}
+
+export function stopTimer() {
+    if (timerState.interval) {
+        clearInterval(timerState.interval);
+        timerState.interval = null;
+    }
+    timerState.running = false;
+    timerState.remaining = 0;
+    updateDisplay();
+}
+
+export function isTimerRunning() {
+    return timerState.running;
+}


### PR DESCRIPTION
## Summary
- implement countdown timer module
- start/stop timer in navigation logic
- auto-advance image questions while timer running
- style timer with retro scoreboard look
- define sample timed questions for SYM and NONSYM

## Testing
- `npm test` *(fails: no test script)*

------
https://chatgpt.com/codex/tasks/task_e_6881dc0f2484832795142e522c5c875d