### PR TITLE
Add debug timer controls & full question sets

### DIFF
--- a/assets/tasks/NONSYM.json
+++ b/assets/tasks/NONSYM.json
@@ -1,12 +1,1199 @@
 {
   "id": "nonsym",
-  "title": "非符號關係",
+  "title": "非符號數量比較",
+  "timer": 120,
   "questions": [
     {
-      "id": "nonsym_q1",
+      "id": "NONSYM_ins1",
+      "type": "instruction",
+      "label": "此測驗採用計時方式，小朋友需在兩分鐘內盡量答完。\n「你睇吓啲點點，話俾我聽邊一格有多啲點點。」"
+    },
+    {
+      "id": "NONSYM_S1",
+      "type": "image-choice",
+      "label": "邊格有多啲點點？",
+      "options": [
+        {
+          "value": "A",
+          "label": "左邊"
+        },
+        {
+          "value": "B",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "A"
+      }
+    },
+    {
+      "id": "NONSYM_P1",
+      "type": "image-choice",
+      "label": "Practice 1",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ]
+    },
+    {
+      "id": "NONSYM_P2",
+      "type": "image-choice",
+      "label": "Practice 2",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ]
+    },
+    {
+      "id": "NONSYM_P3",
+      "type": "image-choice",
+      "label": "Practice 3",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ]
+    },
+    {
+      "id": "NONSYM_P4",
+      "type": "image-choice",
+      "label": "Practice 4",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ]
+    },
+    {
+      "id": "NONSYM_P5",
+      "type": "image-choice",
+      "label": "Practice 5",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ]
+    },
+    {
+      "id": "NONSYM_P6",
+      "type": "image-choice",
+      "label": "Practice 6",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ]
+    },
+    {
+      "id": "NONSYM_P7",
+      "type": "image-choice",
+      "label": "Practice 7",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ]
+    },
+    {
+      "id": "NONSYM_P8",
+      "type": "image-choice",
+      "label": "Practice 8",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ]
+    },
+    {
+      "id": "NONSYM_P9",
+      "type": "image-choice",
+      "label": "Practice 9",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ]
+    },
+    {
+      "id": "NONSYM_ins2",
+      "type": "instruction",
+      "label": "做得好好，跟住會計時兩分鐘，你試下好似啱啱咁，好快咁指俾我睇邊個多啲點點，準備好未?"
+    },
+    {
+      "id": "NONSYM_1",
+      "type": "image-choice",
+      "label": "非符號數量比較",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "L"
+      }
+    },
+    {
+      "id": "NONSYM_2",
+      "type": "image-choice",
+      "label": "非符號數量比較",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "R"
+      }
+    },
+    {
+      "id": "NONSYM_3",
+      "type": "image-choice",
+      "label": "非符號數量比較",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "L"
+      }
+    },
+    {
+      "id": "NONSYM_4",
+      "type": "image-choice",
+      "label": "非符號數量比較",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "R"
+      }
+    },
+    {
+      "id": "NONSYM_5",
+      "type": "image-choice",
+      "label": "非符號數量比較",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "L"
+      }
+    },
+    {
+      "id": "NONSYM_6",
+      "type": "image-choice",
+      "label": "非符號數量比較",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "R"
+      }
+    },
+    {
+      "id": "NONSYM_7",
+      "type": "image-choice",
+      "label": "非符號數量比較",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "L"
+      }
+    },
+    {
+      "id": "NONSYM_8",
+      "type": "image-choice",
+      "label": "非符號數量比較",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "R"
+      }
+    },
+    {
+      "id": "NONSYM_9",
+      "type": "image-choice",
+      "label": "非符號數量比較",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "L"
+      }
+    },
+    {
+      "id": "NONSYM_10",
+      "type": "image-choice",
+      "label": "非符號數量比較",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "R"
+      }
+    },
+    {
+      "id": "NONSYM_11",
+      "type": "image-choice",
+      "label": "非符號數量比較",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "L"
+      }
+    },
+    {
+      "id": "NONSYM_12",
+      "type": "image-choice",
+      "label": "非符號數量比較",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "R"
+      }
+    },
+    {
+      "id": "NONSYM_13",
+      "type": "image-choice",
+      "label": "非符號數量比較",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "L"
+      }
+    },
+    {
+      "id": "NONSYM_14",
+      "type": "image-choice",
+      "label": "非符號數量比較",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "R"
+      }
+    },
+    {
+      "id": "NONSYM_15",
+      "type": "image-choice",
+      "label": "非符號數量比較",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "L"
+      }
+    },
+    {
+      "id": "NONSYM_16",
+      "type": "image-choice",
+      "label": "非符號數量比較",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "R"
+      }
+    },
+    {
+      "id": "NONSYM_17",
+      "type": "image-choice",
+      "label": "非符號數量比較",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "L"
+      }
+    },
+    {
+      "id": "NONSYM_18",
+      "type": "image-choice",
+      "label": "非符號數量比較",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "R"
+      }
+    },
+    {
+      "id": "NONSYM_19",
+      "type": "image-choice",
+      "label": "非符號數量比較",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "L"
+      }
+    },
+    {
+      "id": "NONSYM_20",
+      "type": "image-choice",
+      "label": "非符號數量比較",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "R"
+      }
+    },
+    {
+      "id": "NONSYM_21",
+      "type": "image-choice",
+      "label": "非符號數量比較",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "L"
+      }
+    },
+    {
+      "id": "NONSYM_22",
+      "type": "image-choice",
+      "label": "非符號數量比較",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "R"
+      }
+    },
+    {
+      "id": "NONSYM_23",
+      "type": "image-choice",
+      "label": "非符號數量比較",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "L"
+      }
+    },
+    {
+      "id": "NONSYM_24",
+      "type": "image-choice",
+      "label": "非符號數量比較",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "R"
+      }
+    },
+    {
+      "id": "NONSYM_25",
+      "type": "image-choice",
+      "label": "非符號數量比較",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "L"
+      }
+    },
+    {
+      "id": "NONSYM_26",
+      "type": "image-choice",
+      "label": "非符號數量比較",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "R"
+      }
+    },
+    {
+      "id": "NONSYM_27",
+      "type": "image-choice",
+      "label": "非符號數量比較",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "L"
+      }
+    },
+    {
+      "id": "NONSYM_28",
+      "type": "image-choice",
+      "label": "非符號數量比較",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "R"
+      }
+    },
+    {
+      "id": "NONSYM_29",
+      "type": "image-choice",
+      "label": "非符號數量比較",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "L"
+      }
+    },
+    {
+      "id": "NONSYM_30",
+      "type": "image-choice",
+      "label": "非符號數量比較",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "R"
+      }
+    },
+    {
+      "id": "NONSYM_31",
+      "type": "image-choice",
+      "label": "非符號數量比較",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "L"
+      }
+    },
+    {
+      "id": "NONSYM_32",
+      "type": "image-choice",
+      "label": "非符號數量比較",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "R"
+      }
+    },
+    {
+      "id": "NONSYM_33",
+      "type": "image-choice",
+      "label": "非符號數量比較",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "L"
+      }
+    },
+    {
+      "id": "NONSYM_34",
+      "type": "image-choice",
+      "label": "非符號數量比較",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "R"
+      }
+    },
+    {
+      "id": "NONSYM_35",
+      "type": "image-choice",
+      "label": "非符號數量比較",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "L"
+      }
+    },
+    {
+      "id": "NONSYM_36",
+      "type": "image-choice",
+      "label": "非符號數量比較",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "R"
+      }
+    },
+    {
+      "id": "NONSYM_37",
+      "type": "image-choice",
+      "label": "非符號數量比較",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "L"
+      }
+    },
+    {
+      "id": "NONSYM_38",
+      "type": "image-choice",
+      "label": "非符號數量比較",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "R"
+      }
+    },
+    {
+      "id": "NONSYM_39",
+      "type": "image-choice",
+      "label": "非符號數量比較",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "L"
+      }
+    },
+    {
+      "id": "NONSYM_40",
+      "type": "image-choice",
+      "label": "非符號數量比較",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "R"
+      }
+    },
+    {
+      "id": "NONSYM_41",
+      "type": "image-choice",
+      "label": "非符號數量比較",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "L"
+      }
+    },
+    {
+      "id": "NONSYM_42",
+      "type": "image-choice",
+      "label": "非符號數量比較",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "R"
+      }
+    },
+    {
+      "id": "NONSYM_43",
+      "type": "image-choice",
+      "label": "非符號數量比較",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "L"
+      }
+    },
+    {
+      "id": "NONSYM_44",
+      "type": "image-choice",
+      "label": "非符號數量比較",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "R"
+      }
+    },
+    {
+      "id": "NONSYM_45",
+      "type": "image-choice",
+      "label": "非符號數量比較",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "L"
+      }
+    },
+    {
+      "id": "NONSYM_46",
+      "type": "image-choice",
+      "label": "非符號數量比較",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "R"
+      }
+    },
+    {
+      "id": "NONSYM_47",
+      "type": "image-choice",
+      "label": "非符號數量比較",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "L"
+      }
+    },
+    {
+      "id": "NONSYM_48",
+      "type": "image-choice",
+      "label": "非符號數量比較",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "R"
+      }
+    },
+    {
+      "id": "NONSYM_49",
+      "type": "image-choice",
+      "label": "非符號數量比較",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "L"
+      }
+    },
+    {
+      "id": "NONSYM_50",
+      "type": "image-choice",
+      "label": "非符號數量比較",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "R"
+      }
+    },
+    {
+      "id": "NONSYM_51",
+      "type": "image-choice",
+      "label": "非符號數量比較",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "L"
+      }
+    },
+    {
+      "id": "NONSYM_52",
+      "type": "image-choice",
+      "label": "非符號數量比較",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "R"
+      }
+    },
+    {
+      "id": "NONSYM_53",
+      "type": "image-choice",
+      "label": "非符號數量比較",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "L"
+      }
+    },
+    {
+      "id": "NONSYM_54",
+      "type": "image-choice",
+      "label": "非符號數量比較",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "R"
+      }
+    },
+    {
+      "id": "NONSYM_55",
+      "type": "image-choice",
+      "label": "非符號數量比較",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "L"
+      }
+    },
+    {
+      "id": "NONSYM_56",
+      "type": "image-choice",
+      "label": "非符號數量比較",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "R"
+      }
+    },
+    {
+      "id": "NONSYM_timeout",
+      "type": "instruction",
+      "label": "時間到／已完成，請進行下一部分。"
+    },
+    {
+      "id": "NONSYM_Date",
       "type": "text",
-      "label": "這是一個非符號關係的佔位問題。",
-      "required": true
+      "label": "完成日期："
+    },
+    {
+      "id": "NONSYM_Com",
+      "type": "radio",
+      "label": "已完成",
+      "options": [
+        {
+          "value": "done",
+          "label": "已完成"
+        }
+      ]
     }
   ]
 }

--- a/assets/tasks/SYM.json
+++ b/assets/tasks/SYM.json
@@ -1,12 +1,1240 @@
 {
   "id": "sym",
-  "title": "符號關係",
+  "title": "符號數字比較",
+  "timer": 120,
   "questions": [
     {
-      "id": "sym_q1",
+      "id": "SYM_Cover",
+      "type": "instruction",
+      "label": "Symbolic \n\n確認進入測試請按右下方箭頭（➜）"
+    },
+    {
+      "id": "SYM_ins1",
+      "type": "instruction",
+      "label": "此測驗採用計時方式，小朋友需在兩分鐘內盡量答完。\n「你睇吓啲數字，話俾我聽邊一個數字比較大?」"
+    },
+    {
+      "id": "SYM_S1",
+      "type": "image-choice",
+      "label": "邊個大啲？1定係7？",
+      "options": [
+        {
+          "value": "1",
+          "label": "1"
+        },
+        {
+          "value": "7",
+          "label": "7"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "7"
+      }
+    },
+    {
+      "id": "SYM_S2",
+      "type": "image-choice",
+      "label": "邊個大啲？8定係2？",
+      "options": [
+        {
+          "value": "8",
+          "label": "8"
+        },
+        {
+          "value": "2",
+          "label": "2"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "8"
+      }
+    },
+    {
+      "id": "SYM_S3",
+      "type": "image-choice",
+      "label": "邊個大啲？2定係5？",
+      "options": [
+        {
+          "value": "2",
+          "label": "2"
+        },
+        {
+          "value": "5",
+          "label": "5"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "5"
+      }
+    },
+    {
+      "id": "SYM_P1",
+      "type": "image-choice",
+      "label": "Practice 1",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ]
+    },
+    {
+      "id": "SYM_P2",
+      "type": "image-choice",
+      "label": "Practice 2",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ]
+    },
+    {
+      "id": "SYM_P3",
+      "type": "image-choice",
+      "label": "Practice 3",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ]
+    },
+    {
+      "id": "SYM_P4",
+      "type": "image-choice",
+      "label": "Practice 4",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ]
+    },
+    {
+      "id": "SYM_P5",
+      "type": "image-choice",
+      "label": "Practice 5",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ]
+    },
+    {
+      "id": "SYM_P6",
+      "type": "image-choice",
+      "label": "Practice 6",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ]
+    },
+    {
+      "id": "SYM_P7",
+      "type": "image-choice",
+      "label": "Practice 7",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ]
+    },
+    {
+      "id": "SYM_P8",
+      "type": "image-choice",
+      "label": "Practice 8",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ]
+    },
+    {
+      "id": "SYM_P9",
+      "type": "image-choice",
+      "label": "Practice 9",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ]
+    },
+    {
+      "id": "SYM_ins2",
+      "type": "instruction",
+      "label": "做得好，跟住會計時兩分鐘，你試下好似啱啱咁，好快咁指俾我睇邊個數字大啲，準備好就開始啦。"
+    },
+    {
+      "id": "SYM_1",
+      "type": "image-choice",
+      "label": "數字大小比較測試",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "L"
+      }
+    },
+    {
+      "id": "SYM_2",
+      "type": "image-choice",
+      "label": "數字大小比較測試",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "R"
+      }
+    },
+    {
+      "id": "SYM_3",
+      "type": "image-choice",
+      "label": "數字大小比較測試",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "L"
+      }
+    },
+    {
+      "id": "SYM_4",
+      "type": "image-choice",
+      "label": "數字大小比較測試",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "R"
+      }
+    },
+    {
+      "id": "SYM_5",
+      "type": "image-choice",
+      "label": "數字大小比較測試",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "L"
+      }
+    },
+    {
+      "id": "SYM_6",
+      "type": "image-choice",
+      "label": "數字大小比較測試",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "R"
+      }
+    },
+    {
+      "id": "SYM_7",
+      "type": "image-choice",
+      "label": "數字大小比較測試",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "L"
+      }
+    },
+    {
+      "id": "SYM_8",
+      "type": "image-choice",
+      "label": "數字大小比較測試",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "R"
+      }
+    },
+    {
+      "id": "SYM_9",
+      "type": "image-choice",
+      "label": "數字大小比較測試",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "L"
+      }
+    },
+    {
+      "id": "SYM_10",
+      "type": "image-choice",
+      "label": "數字大小比較測試",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "R"
+      }
+    },
+    {
+      "id": "SYM_11",
+      "type": "image-choice",
+      "label": "數字大小比較測試",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "L"
+      }
+    },
+    {
+      "id": "SYM_12",
+      "type": "image-choice",
+      "label": "數字大小比較測試",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "R"
+      }
+    },
+    {
+      "id": "SYM_13",
+      "type": "image-choice",
+      "label": "數字大小比較測試",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "L"
+      }
+    },
+    {
+      "id": "SYM_14",
+      "type": "image-choice",
+      "label": "數字大小比較測試",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "R"
+      }
+    },
+    {
+      "id": "SYM_15",
+      "type": "image-choice",
+      "label": "數字大小比較測試",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "L"
+      }
+    },
+    {
+      "id": "SYM_16",
+      "type": "image-choice",
+      "label": "數字大小比較測試",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "R"
+      }
+    },
+    {
+      "id": "SYM_17",
+      "type": "image-choice",
+      "label": "數字大小比較測試",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "L"
+      }
+    },
+    {
+      "id": "SYM_18",
+      "type": "image-choice",
+      "label": "數字大小比較測試",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "R"
+      }
+    },
+    {
+      "id": "SYM_19",
+      "type": "image-choice",
+      "label": "數字大小比較測試",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "L"
+      }
+    },
+    {
+      "id": "SYM_20",
+      "type": "image-choice",
+      "label": "數字大小比較測試",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "R"
+      }
+    },
+    {
+      "id": "SYM_21",
+      "type": "image-choice",
+      "label": "數字大小比較測試",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "L"
+      }
+    },
+    {
+      "id": "SYM_22",
+      "type": "image-choice",
+      "label": "數字大小比較測試",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "R"
+      }
+    },
+    {
+      "id": "SYM_23",
+      "type": "image-choice",
+      "label": "數字大小比較測試",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "L"
+      }
+    },
+    {
+      "id": "SYM_24",
+      "type": "image-choice",
+      "label": "數字大小比較測試",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "R"
+      }
+    },
+    {
+      "id": "SYM_25",
+      "type": "image-choice",
+      "label": "數字大小比較測試",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "L"
+      }
+    },
+    {
+      "id": "SYM_26",
+      "type": "image-choice",
+      "label": "數字大小比較測試",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "R"
+      }
+    },
+    {
+      "id": "SYM_27",
+      "type": "image-choice",
+      "label": "數字大小比較測試",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "L"
+      }
+    },
+    {
+      "id": "SYM_28",
+      "type": "image-choice",
+      "label": "數字大小比較測試",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "R"
+      }
+    },
+    {
+      "id": "SYM_29",
+      "type": "image-choice",
+      "label": "數字大小比較測試",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "L"
+      }
+    },
+    {
+      "id": "SYM_30",
+      "type": "image-choice",
+      "label": "數字大小比較測試",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "R"
+      }
+    },
+    {
+      "id": "SYM_31",
+      "type": "image-choice",
+      "label": "數字大小比較測試",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "L"
+      }
+    },
+    {
+      "id": "SYM_32",
+      "type": "image-choice",
+      "label": "數字大小比較測試",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "R"
+      }
+    },
+    {
+      "id": "SYM_33",
+      "type": "image-choice",
+      "label": "數字大小比較測試",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "L"
+      }
+    },
+    {
+      "id": "SYM_34",
+      "type": "image-choice",
+      "label": "數字大小比較測試",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "R"
+      }
+    },
+    {
+      "id": "SYM_35",
+      "type": "image-choice",
+      "label": "數字大小比較測試",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "L"
+      }
+    },
+    {
+      "id": "SYM_36",
+      "type": "image-choice",
+      "label": "數字大小比較測試",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "R"
+      }
+    },
+    {
+      "id": "SYM_37",
+      "type": "image-choice",
+      "label": "數字大小比較測試",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "L"
+      }
+    },
+    {
+      "id": "SYM_38",
+      "type": "image-choice",
+      "label": "數字大小比較測試",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "R"
+      }
+    },
+    {
+      "id": "SYM_39",
+      "type": "image-choice",
+      "label": "數字大小比較測試",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "L"
+      }
+    },
+    {
+      "id": "SYM_40",
+      "type": "image-choice",
+      "label": "數字大小比較測試",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "R"
+      }
+    },
+    {
+      "id": "SYM_41",
+      "type": "image-choice",
+      "label": "數字大小比較測試",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "L"
+      }
+    },
+    {
+      "id": "SYM_42",
+      "type": "image-choice",
+      "label": "數字大小比較測試",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "R"
+      }
+    },
+    {
+      "id": "SYM_43",
+      "type": "image-choice",
+      "label": "數字大小比較測試",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "L"
+      }
+    },
+    {
+      "id": "SYM_44",
+      "type": "image-choice",
+      "label": "數字大小比較測試",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "R"
+      }
+    },
+    {
+      "id": "SYM_45",
+      "type": "image-choice",
+      "label": "數字大小比較測試",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "L"
+      }
+    },
+    {
+      "id": "SYM_46",
+      "type": "image-choice",
+      "label": "數字大小比較測試",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "R"
+      }
+    },
+    {
+      "id": "SYM_47",
+      "type": "image-choice",
+      "label": "數字大小比較測試",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "L"
+      }
+    },
+    {
+      "id": "SYM_48",
+      "type": "image-choice",
+      "label": "數字大小比較測試",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "R"
+      }
+    },
+    {
+      "id": "SYM_49",
+      "type": "image-choice",
+      "label": "數字大小比較測試",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "L"
+      }
+    },
+    {
+      "id": "SYM_50",
+      "type": "image-choice",
+      "label": "數字大小比較測試",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "R"
+      }
+    },
+    {
+      "id": "SYM_51",
+      "type": "image-choice",
+      "label": "數字大小比較測試",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "L"
+      }
+    },
+    {
+      "id": "SYM_52",
+      "type": "image-choice",
+      "label": "數字大小比較測試",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "R"
+      }
+    },
+    {
+      "id": "SYM_53",
+      "type": "image-choice",
+      "label": "數字大小比較測試",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "L"
+      }
+    },
+    {
+      "id": "SYM_54",
+      "type": "image-choice",
+      "label": "數字大小比較測試",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "R"
+      }
+    },
+    {
+      "id": "SYM_55",
+      "type": "image-choice",
+      "label": "數字大小比較測試",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "L"
+      }
+    },
+    {
+      "id": "SYM_56",
+      "type": "image-choice",
+      "label": "數字大小比較測試",
+      "options": [
+        {
+          "value": "L",
+          "label": "左邊"
+        },
+        {
+          "value": "R",
+          "label": "右邊"
+        }
+      ],
+      "scoring": {
+        "correctAnswer": "R"
+      }
+    },
+    {
+      "id": "SYM_timeout",
+      "type": "instruction",
+      "label": "時間到／已完成，請進行下一部分。"
+    },
+    {
+      "id": "SYM_Date",
       "type": "text",
-      "label": "這是一個符號關係的佔位問題。",
-      "required": true
+      "label": "完成日期："
+    },
+    {
+      "id": "SYM_Com",
+      "type": "radio",
+      "label": "已完成",
+      "options": [
+        {
+          "value": "done",
+          "label": "已完成"
+        }
+      ]
     }
   ]
 }

--- a/css/modules/pages.css
+++ b/css/modules/pages.css
@@ -150,6 +150,7 @@
 .survey-header {
     text-align: center;
     margin-bottom: 30px;
+    position: relative;
 }
 
 #current-section-display {
@@ -170,10 +171,19 @@
 }
 
 #timer {
-    font-size: 20px;
+    font-size: 28px;
     font-weight: bold;
-    color: #2b3990;
-    margin-top: 10px;
+    font-family: 'Courier New', monospace;
+    background: #222;
+    color: #0f0;
+    padding: 4px 8px;
+    border-radius: 4px;
+    position: absolute;
+    top: 0;
+    right: 0;
+    margin-top: 0;
+    display: inline-block;
+    pointer-events: none;
 }
 
 #question-container {

--- a/index.html
+++ b/index.html
@@ -65,6 +65,8 @@
                     </div>
                     <div id="debug-controls" class="hidden">
                         <button id="add-question-btn">Add Question</button>
+                        <button id="stop-timer-btn">Stop Timer</button>
+                        <button id="end-timer-btn">End Timer</button>
                         <div id="debug-info"></div>
                     </div>
                 </div>

--- a/js/modules/debug.js
+++ b/js/modules/debug.js
@@ -1,10 +1,13 @@
 import { state, logDebug } from './state.js';
 import { renderCurrentQuestion } from './question.js';
+import { stopTimer, finishTimer, isTimerRunning } from './timer.js';
 
 export function initializeDebug() {
     const trigger = document.getElementById('debug-trigger');
     const controls = document.getElementById('debug-controls');
     const addBtn = document.getElementById('add-question-btn');
+    const stopBtn = document.getElementById('stop-timer-btn');
+    const endBtn = document.getElementById('end-timer-btn');
 
     if (trigger) {
         trigger.addEventListener('click', (e) => {
@@ -56,6 +59,24 @@ export function initializeDebug() {
             section.questions.push(q);
             renderCurrentQuestion();
             logDebug('Question added via debug UI', q);
+        });
+    }
+
+    if (stopBtn) {
+        stopBtn.addEventListener('click', () => {
+            if (isTimerRunning()) {
+                stopTimer();
+                logDebug('Timer stopped via debug');
+            }
+        });
+    }
+
+    if (endBtn) {
+        endBtn.addEventListener('click', () => {
+            if (isTimerRunning()) {
+                finishTimer();
+                logDebug('Timer ended via debug');
+            }
         });
     }
 }

--- a/js/modules/question.js
+++ b/js/modules/question.js
@@ -1,5 +1,7 @@
 import { state } from './state.js';
 import { evaluateTermination, terminationRules, calculateScore } from './terminations.js';
+import { navigatePage } from './navigation.js';
+import { isTimerRunning } from './timer.js';
 
 const debugInfoEl = document.getElementById('debug-info');
 
@@ -199,6 +201,9 @@ export function renderCurrentQuestion() {
                 radioGroup.appendChild(labelEl);
             });
             questionWrapper.appendChild(radioGroup);
+            if (isTimerRunning() && state.autoNext) {
+                radioGroup.addEventListener('change', () => navigatePage(1));
+            }
             break;
         case 'image-choice':
             const imgGroup = document.createElement('div');
@@ -226,6 +231,9 @@ export function renderCurrentQuestion() {
                 imgGroup.appendChild(labelImg);
             });
             questionWrapper.appendChild(imgGroup);
+            if (isTimerRunning() && state.autoNext) {
+                imgGroup.addEventListener('change', () => navigatePage(1));
+            }
             break;
         // Add more cases for 'select', 'radio', 'checkbox', etc. here
         default:

--- a/js/modules/state.js
+++ b/js/modules/state.js
@@ -18,7 +18,9 @@ export const state = {
     completed: false,
     infoDisplayInterval: null,
     debugMode: false,
-    pendingTermination: null
+    pendingTermination: null,
+    timerSection: null,
+    autoNext: false
 };
 
 export function formatTimestamp(date) {

--- a/js/modules/timer.js
+++ b/js/modules/timer.js
@@ -1,0 +1,66 @@
+export const timerState = {
+    remaining: 0,
+    interval: null,
+    callback: null,
+    running: false
+};
+
+const timerEl = document.getElementById('timer');
+
+function formatTime(sec) {
+    const m = String(Math.floor(sec / 60)).padStart(2, '0');
+    const s = String(sec % 60).padStart(2, '0');
+    return `${m}:${s}`;
+}
+
+function updateDisplay() {
+    if (timerEl) {
+        timerEl.textContent = formatTime(timerState.remaining);
+    }
+}
+
+export function startTimer(seconds, cb) {
+    clearInterval(timerState.interval);
+    timerState.remaining = seconds;
+    timerState.callback = cb;
+    timerState.running = true;
+    updateDisplay();
+    timerState.interval = setInterval(() => {
+        timerState.remaining--;
+        if (timerState.remaining <= 0) {
+            stopTimer();
+            if (typeof timerState.callback === 'function') {
+                timerState.callback();
+            }
+        }
+        updateDisplay();
+    }, 1000);
+}
+
+export function stopTimer() {
+    if (timerState.interval) {
+        clearInterval(timerState.interval);
+        timerState.interval = null;
+    }
+    timerState.running = false;
+    timerState.remaining = 0;
+    updateDisplay();
+}
+
+export function finishTimer() {
+    if (timerState.interval) {
+        clearInterval(timerState.interval);
+        timerState.interval = null;
+    }
+    const cb = timerState.callback;
+    timerState.running = false;
+    timerState.remaining = 0;
+    updateDisplay();
+    if (typeof cb === 'function') {
+        cb();
+    }
+}
+
+export function isTimerRunning() {
+    return timerState.running;
+}


### PR DESCRIPTION
## Summary
- flesh out SYM and NONSYM task JSON with 56 timed questions each
- pin timer in header with retro look
- allow debug controls to stop or end the timer
- expose timer helper to finish countdown programmatically

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6881dc0f2484832795142e522c5c875d