### PR TITLE
Update timer logic and merge symbolic surveys

### DIFF
--- a/assets/survey-structure.json
+++ b/assets/survey-structure.json
@@ -25,12 +25,8 @@
           "order": 2
         },
         {
-          "file": "NONSYM.json",
-          "order": 3
-        },
-        {
           "file": "TheoryofMind.json",
-          "order": 4
+          "order": 3
         }
       ]
     },

--- a/assets/tasks/SYM.json
+++ b/assets/tasks/SYM.json
@@ -1,6 +1,6 @@
 {
   "id": "sym",
-  "title": "符號數字比較",
+  "title": "Symbolic (Individual)",
   "timer": 120,
   "questions": [
     {

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
                         <h2 id="current-section-display"></h2>
                         <p id="page-info"></p>
                         <p id="question-id-display" class="question-id"></p>
-                        <div id="timer"></div>
+                        <div id="timer" class="hidden"></div>
                     </div>
                     <div id="question-container"></div>
                     <div class="survey-navigation">

--- a/js/modules/data.js
+++ b/js/modules/data.js
@@ -28,7 +28,16 @@ export function fetchSurveyData() {
                     })
             );
 
-            return Promise.all(loadPromises);
+            return Promise.all(loadPromises).then(() => {
+                return fetch('assets/tasks/NONSYM.json')
+                    .then(resp => resp.json())
+                    .then(nonsym => {
+                        if (state.surveySections['sym']) {
+                            state.surveySections['sym'].questions = state.surveySections['sym'].questions.concat(nonsym.questions);
+                        }
+                        state.surveySections['nonsym'] = nonsym;
+                    });
+            });
         });
 }
 

--- a/js/modules/navigation.js
+++ b/js/modules/navigation.js
@@ -75,16 +75,6 @@ export function navigatePage(direction) {
                     renderCurrentQuestion();
                 }
             });
-        } else if (section.id === 'nonsym' && prevQuestion && prevQuestion.id === 'NONSYM_ins2') {
-            state.timerSection = 'nonsym';
-            state.autoNext = true;
-            startTimer(120, () => {
-                const idx = section.questions.findIndex(q => q.id === 'NONSYM_timeout');
-                if (idx !== -1) {
-                    state.currentPage = idx;
-                    renderCurrentQuestion();
-                }
-            });
         }
     }
 
@@ -102,6 +92,11 @@ export function navigatePage(direction) {
     if (newPage < 0) {
         showToc();
     } else if (newPage >= 0 && newPage < section.questions.length) {
+        const nextQuestion = section.questions[newPage];
+        if (nextQuestion && nextQuestion.id === 'SYM_timeout') {
+            stopTimer();
+            state.autoNext = false;
+        }
         state.currentPage = newPage;
         renderCurrentQuestion();
     } else if (newPage >= section.questions.length) {

--- a/js/modules/timer.js
+++ b/js/modules/timer.js
@@ -7,6 +7,14 @@ export const timerState = {
 
 const timerEl = document.getElementById('timer');
 
+function showTimer() {
+    if (timerEl) timerEl.classList.remove('hidden');
+}
+
+function hideTimer() {
+    if (timerEl) timerEl.classList.add('hidden');
+}
+
 function formatTime(sec) {
     const m = String(Math.floor(sec / 60)).padStart(2, '0');
     const s = String(sec % 60).padStart(2, '0');
@@ -24,6 +32,7 @@ export function startTimer(seconds, cb) {
     timerState.remaining = seconds;
     timerState.callback = cb;
     timerState.running = true;
+    showTimer();
     updateDisplay();
     timerState.interval = setInterval(() => {
         timerState.remaining--;
@@ -44,6 +53,7 @@ export function stopTimer() {
     }
     timerState.running = false;
     timerState.remaining = 0;
+    hideTimer();
     updateDisplay();
 }
 
@@ -55,6 +65,7 @@ export function finishTimer() {
     const cb = timerState.callback;
     timerState.running = false;
     timerState.remaining = 0;
+    hideTimer();
     updateDisplay();
     if (typeof cb === 'function') {
         cb();


### PR DESCRIPTION
## Summary
- hide timer until symbolic survey starts and stop at timeout
- merge NONSYM questions with SYM during load
- remove NONSYM section from survey structure
- rename SYM survey to "Symbolic (Individual)"
- update timer visibility handling

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6881e39d789083278ad630df9ca8fab9