### PR TITLE
Remove unused TOC elements and fix section counts

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,8 +42,6 @@
                     <div class="toc-container">
                         <h2 id="toc-title">問卷部分</h2>
                         <p id="toc-instructions">請選擇一個部分開始問卷。</p>
-                        <p id="toc-start-date"></p>
-                        <p id="toc-end-date"></p>
                         <div id="toc-list">
                             <!-- Table of Contents sections will be loaded here -->
                         </div>

--- a/js/modules/ui.js
+++ b/js/modules/ui.js
@@ -98,7 +98,13 @@ export function renderToc() {
         tocItem.dataset.section = section.id;
 
         const answered = section.questions.filter(q => state.userResponses[q.id]).length;
-        const total = section.questions.length;
+        let total = section.questions.length;
+        if (section.id === 'sym' && state.surveySections['nonsym']) {
+            const hasNonsym = section.questions.some(q => q.id && q.id.startsWith('NONSYM_'));
+            if (!hasNonsym) {
+                total += state.surveySections['nonsym'].questions.length;
+            }
+        }
         const timestamps = state.sectionTimestamps[section.id] || {};
 
         const info = document.createElement('div');
@@ -140,6 +146,15 @@ export function renderToc() {
 
     sortedSets.forEach(set => {
         logDebug('renderToc: Processing set:', set.id);
+        const visibleSections = set.sections.filter(sectionInfo => {
+            const sectionId = sectionInfo.file.replace('.json', '');
+            if (sectionId === 'background') return false; // skip background section
+            if (!sectionVisible(sectionInfo)) return false;
+            return state.surveySections[sectionId];
+        });
+
+        if (visibleSections.length === 0) return; // skip empty sets
+
         const setContainer = document.createElement('div');
         setContainer.className = 'toc-set';
 
@@ -148,23 +163,16 @@ export function renderToc() {
         setTitle.textContent = set.name || set.id;
         setContainer.appendChild(setTitle);
 
-        set.sections.forEach(sectionInfo => {
+        visibleSections.forEach(sectionInfo => {
             const sectionId = sectionInfo.file.replace('.json', '');
-            if (sectionId === 'background') return; // skip background section in TOC
-            if (!sectionVisible(sectionInfo)) return; // hide by condition
             const section = state.surveySections[sectionId];
-            if (section) {
-                logDebug(`renderToc:   - Section: ${sectionId}`);
-                const tocItem = createTocItem(section);
-                setContainer.appendChild(tocItem);
-            } else {
-                logDebug(`renderToc:   - Section data for ${sectionId} not found in state.surveySections.`);
-            }
+            const tocItem = createTocItem(section);
+            setContainer.appendChild(tocItem);
         });
+
         tocList.appendChild(setContainer);
     });
     logDebug('renderToc: Finished rendering TOC.');
-    updateSurveyTimestamps();
 }
 
 export function renderSectionJumper() {
@@ -248,15 +256,3 @@ export function updateInfoDisplay() {
     datetimeEl.title = datetimeString;
 }
 
-export function updateSurveyTimestamps() {
-    const startEl = document.getElementById('toc-start-date');
-    const endEl = document.getElementById('toc-end-date');
-    if (startEl) {
-        const startedLabel = labelTranslations.started;
-        startEl.textContent = `${startedLabel}: ${state.startDate || '-'}`;
-    }
-    if (endEl) {
-        const lastLabel = labelTranslations.lastUsed;
-        endEl.textContent = `${lastLabel}: ${state.endDate || '-'}`;
-    }
-}


### PR DESCRIPTION
## Summary
- simplify TOC page layout
- skip empty sets when rendering the TOC
- ensure Symbolic (Individual) counts include NONSYM questions

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6881e6bde7608327b8ec6316f5be9719