### PR TITLE
Remove required section display

### DIFF
--- a/assets/survey-structure.json
+++ b/assets/survey-structure.json
@@ -1,17 +1,6 @@
 {
   "sets": [
     {
-      "id": "required",
-      "name": "必填部分",
-      "order": 1,
-      "sections": [
-        {
-          "file": "background.json",
-          "order": 1
-        }
-      ]
-    },
-    {
       "id": "set1",
       "name": "第一組",
       "order": 2,

--- a/css/modules/pages.css
+++ b/css/modules/pages.css
@@ -119,14 +119,6 @@
     align-items: flex-start;
 }
 
-.toc-item-times {
-    display: flex;
-    gap: 10px;
-    font-size: 12px;
-    color: #666;
-}
-
-
 .toc-set-header {
     margin: 20px 0 10px 0;
     padding: 10px 0;

--- a/js/modules/ui.js
+++ b/js/modules/ui.js
@@ -115,17 +115,6 @@ export function renderToc() {
         title.textContent = section.title || section.id;
         info.appendChild(title);
 
-        const times = document.createElement('div');
-        times.className = 'toc-item-times';
-        const startedLabel = labelTranslations.started;
-        const lastLabel = labelTranslations.lastUsed;
-        const startSpan = document.createElement('span');
-        startSpan.textContent = `${startedLabel}: ${timestamps.start || '-'}`;
-        const lastSpan = document.createElement('span');
-        lastSpan.textContent = `${lastLabel}: ${timestamps.lastUsed || '-'}`;
-        times.appendChild(startSpan);
-        times.appendChild(lastSpan);
-        info.appendChild(times);
 
         const progress = document.createElement('div');
         progress.className = 'toc-item-progress';


### PR DESCRIPTION
## Summary
- remove the `required` set from the survey structure so the `必填部分` tag no longer appears
- drop timestamps from TOC items
- clean up CSS for the removed timestamps

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6881e9386d5c8327981cbbd21baf6804