### PR TITLE
Fix entry form loading

### DIFF
--- a/js/modules/data.js
+++ b/js/modules/data.js
@@ -13,6 +13,11 @@ export function fetchSurveyData() {
                 const setFiles = set.sections.map(section => section.file);
                 state.sectionFiles = state.sectionFiles.concat(setFiles);
             });
+
+            // Always include background.json so the entry form is loaded
+            if (!state.sectionFiles.includes('background.json')) {
+                state.sectionFiles.unshift('background.json');
+            }
             
             const loadPromises = state.sectionFiles.map(file =>
                 fetch(`assets/tasks/${file}`)


### PR DESCRIPTION
## Summary
- always load `background.json` when fetching survey data so the entry form shows again

## Testing
- `node -e "require('./js/modules/data.js')"`

------
https://chatgpt.com/codex/tasks/task_e_6881ec394a9483279235a3dd10ced3ee