### PR TITLE
Fix countdown timer visibility for SYM and NONSYM questions

### DIFF
--- a/js/modules/navigation.js
+++ b/js/modules/navigation.js
@@ -75,7 +75,7 @@ export function navigatePage(direction) {
                     renderCurrentQuestion();
                 }
             });
-        } else if (section.id === 'sym' && prevQuestion && prevQuestion.id === 'NONSYM_ins2') {
+        } else if (section.id === 'nonsym' && prevQuestion && prevQuestion.id === 'NONSYM_ins2') {
             state.timerSection = 'nonsym';
             state.autoNext = true;
             startTimer(120, () => {

--- a/js/modules/question.js
+++ b/js/modules/question.js
@@ -1,7 +1,7 @@
 import { state } from './state.js';
 import { evaluateTermination, terminationRules, calculateScore } from './terminations.js';
 import { navigatePage } from './navigation.js';
-import { isTimerRunning } from './timer.js';
+import { isTimerRunning, setTimerVisibility } from './timer.js';
 
 const debugInfoEl = document.getElementById('debug-info');
 
@@ -105,6 +105,14 @@ export function renderCurrentQuestion() {
         questionContainer.innerHTML = 'Error: Question not found.';
         return;
     }
+
+    const symPattern = /^SYM_(?:[1-9]|[1-4][0-9]|5[0-6])$/;
+    const nonsymPattern = /^NONSYM_(?:[1-9]|[1-4][0-9]|5[0-6])$/;
+    const showTimerNow =
+        isTimerRunning() &&
+        ((state.timerSection === 'sym' && symPattern.test(question.id)) ||
+         (state.timerSection === 'nonsym' && nonsymPattern.test(question.id)));
+    setTimerVisibility(showTimerNow);
 
     const terminationInfo = evaluateTermination(section.id, question.id);
     if (terminationInfo) {

--- a/js/modules/timer.js
+++ b/js/modules/timer.js
@@ -1,4 +1,3 @@
-import { state } from './state.js';
 
 export const timerState = {
     remaining: 0,
@@ -11,16 +10,20 @@ const timerEl = document.getElementById('timer');
 
 function showTimer() {
     if (timerEl) {
-        if (['sym', 'nonsym'].includes(state.timerSection)) {
-            timerEl.classList.remove('hidden');
-        } else {
-            timerEl.classList.add('hidden');
-        }
+        timerEl.classList.remove('hidden');
     }
 }
 
 function hideTimer() {
     if (timerEl) timerEl.classList.add('hidden');
+}
+
+export function setTimerVisibility(visible) {
+    if (visible) {
+        showTimer();
+    } else {
+        hideTimer();
+    }
 }
 
 function formatTime(sec) {


### PR DESCRIPTION
## Summary
- export `setTimerVisibility` utility in timer module
- toggle timer display in `renderCurrentQuestion`
- simplify timer visibility handling

## Testing
- `node --check js/modules/timer.js`
- `node --check js/modules/question.js`
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6881ed1417688327af864952edc26117